### PR TITLE
feat: v0.1.7 — Tushare DCF 三表扩展 + 股东增减持 + 行业定价 + 版本号收敛

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "invest-A",
       "description": "A股个股调研学习工具。覆盖基本信息、财务报告、行业产业链、估值/市场状态、机构分析师、情绪舆情、宏观政策七大维度，每条分析论述引用数据来源，区分事实陈述与分析判断。学习工具，非决策工具。",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "author": {
         "name": "Veblin",
         "url": "https://github.com/Veblin"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "invest-A",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "A股多因子交叉验证投研助手。九模块研究备忘录（动态驱动/市场结构/左右侧概率），每条数据引用来源，不做买卖建议。",
   "author": {
     "name": "Veblin",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,10 +130,11 @@ Tavily → Bocha → WebSearch（Claude 内置）
 
 ### 发布前检查清单
 
-- [ ] `skills/invest-A/SKILL.md` 为最新 canonical 版本（所有 LAWs、工作流、反模式完整）
-- [ ] `.claude-plugin/plugin.json` 版本号与 SKILL.md 一致
+- [ ] `skills/invest-A/SKILL.md` 为最新规格（所有 LAWs、工作流、反模式完整）
+- [ ] `bash scripts/bump-version.sh X.Y.Z` 已执行（禁止手动改多处版本号）
+- [ ] `bash skills/invest-A/scripts/check-version.sh` 通过
 - [ ] `.claude-plugin/marketplace.json` 描述准确
-- [ ] `.agents/plugins/marketplace.json` 与 claude-plugin 版本同步
+- [ ] `.agents/plugins/marketplace.json` 与 claude-plugin 描述同步
 - [ ] `gemini-extension.json` env vars 与 `.env.example` 一致
 - [ ] `CHANGELOG.md` 已更新
 - [ ] `uv run pytest` 通过
@@ -142,12 +143,17 @@ Tavily → Bocha → WebSearch（Claude 内置）
 
 ### 版本号规范
 
-- `SKILL.md` YAML frontmatter `version`
-- `.claude-plugin/plugin.json` `version`
-- `gemini-extension.json` `version`
-- `pyproject.toml` `version`
+**canonical**：`pyproject.toml` `[project].version`
 
-以上四处版本号必须一致。
+由 `bash scripts/bump-version.sh X.Y.Z` 同步的 5 个文件：
+
+- `pyproject.toml`
+- `skills/invest-A/SKILL.md`（frontmatter `version`）
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`（`plugins[0].version`）
+- `gemini-extension.json`
+
+校验：`bash skills/invest-A/scripts/check-version.sh`（CI / pre-commit 已接入）。
 
 ### 跨 Harness 兼容
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+### 工具链
+
+- **版本号收敛**：新增 `scripts/version_sync.py`；`bump-version.sh` / `check-version.sh` 以 `pyproject.toml` 为 canonical，一键同步 5 个分发 manifest；JSON bump 保留原文件格式
+- **移除运行时版本自检**：删除 SKILL.md Step 0 与 SessionStart 钩子中的 `check-version.sh`（保留 CI / pre-commit 校验）
+- **DCF 预处理串联**：`collect_financials` 输出附加 `dcf_preprocess`（`calc_fcff` / `calc_net_debt`）
+- **cninfo 增减持**：`CNINFO_HOLDER_TIMEOUT_SEC`（默认 45s）超时跳过，避免全市场扫描阻塞采集
+
+### 审查修复（第三轮）
+
+- `collect_industry_pricing`：`collect_industry_pricing_dim` + `collect_all` 延后采集，确保 industry 传入期货映射
+- `cmd_synthesize` 默认 dims 对齐 `_DEFAULT_DIMS`（含 `holder_changes`）
+- `_has_price_signal` 非 dict 安全；`calc_beta` 用 epsilon 判断零方差；`cmd_bump` 失败回滚
+- `_norm_date` 移除不可达第三正则
+- 报告增强提示：`估值分位` → `PE 历史位置`（模块 1 外措辞规范）
+- Step 8 e2e：`test_v017_e2e.py`（`INVEST_RUN_E2E=1` 时跑四标的 collect/report 冒烟）
+
+## v0.1.7 (2026-07-04)
+
+v0.1.7 扩展 Tushare 三表 DCF 字段、新增股东增减持与行业定价采集维度，并为 v0.1.8 DCF 模型预埋估值预处理函数。
+
+### 核心新增
+
+- **P0-1 Tushare 三表扩字段** (`collector.py`)：income/cashflow/balancesheet 补齐 EBIT、CapEx、净债务等 DCF 所需字段
+- **P0-2 holder_changes 维度**：三源（Tushare + akshare ths/cninfo）股东增减持采集、去重合并与报告渲染
+- **P1-1 chain.py 期货映射**：`get_futures_for_industry()` 复用长度降序关键词匹配
+- **P1-2 industry_pricing 维度**：期货现货价格 + 公司新闻涨价信号，挂载至 `attach_phase2_extras`
+- **P2 估值预处理** (`valuation.py`)：`calc_wacc` / `calc_fcff` / `calc_net_debt` / `calc_ev_to_equity` / `calc_beta`
+- **P3 WebSearch 白名单** (`env.py` `PRICE_NEWS_WHITELIST`) + `ReportEnhancer` 触发器统一
+- **P3-3 价格异常检测原型** (`_detect_price_shock`)：近 60 日涨跌停检测，接入 `attach_phase2_extras`
+
+### 审查修复
+
+- `_merge_holder_records`：修正 source_rank key、同源同日多笔不合并、cross_check 仅计 distinct 源
+- `calc_wacc`：debt_weight 缺失时不再输出假 50/50 权重，退化为 cost_of_equity 并附 warning
+- 渲染：NaN avg_price 显示为 `—`；章节编号改为 3d/3e 避免与市场结构 3b/3c 冲突
+- 期货趋势：双日期 spot 对比实现 `trend_30d`（替代恒为"数据不足"的占位）
+- `ReportEnhancer` 输出可操作建议至报告头部（涨价 WebSearch / 估值分位 / 价格 shock）
+- akshare ths `change_vol` 文本解析为数值
+- 移除未使用依赖 `pypdf` / `pycryptodome`（PDF 能力留待 v0.1.9 report_audit）
+
+### 审查修复（第二轮）
+
+- `_is_valuation_extreme` 改为从 `dimensions` 读取估值分位（修复触发器死代码）
+- 涨价新闻增加近 30 日日期过滤
+- `industry_pricing` 渲染拆分：期货→模块 1、涨价信号→模块 2
+- `brief` 模式补充股东增减持章节
+- SKILL.md 补充 WebSearch 白名单指引
+
 ## v0.1.6 (2026-07-02)
 
 v0.1.6 引入事件驱动引擎、Peer 对标 CLI、合规 Lint 引擎、TickFlow K-line 数据源及 Manifest 指纹系统。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md — invest-A 投研助手
 
-> 当前版本：v0.1.7 | 分支：feat/v0.1.7
-
 ## 版本规则
 
 - 最多三位：`v{major}.{minor}.{patch}`
@@ -11,14 +9,18 @@
 
 ### 版本号同步（统一修改）
 
-版本号涉及三个文件：`SKILL.md`（frontmatter）、`CLAUDE.md`（正文）、`pyproject.toml`（项目配置）。**禁止逐个手动修改**，请使用统一的 bump 脚本：
+**canonical 源**：`pyproject.toml` 的 `[project].version`（运行时经 `version.py` 读取）。
+
+**禁止手动改多处版本号**。发布时只运行 bump 脚本，由 `scripts/version_sync.py` 同步 5 个分发 manifest：
 
 ```bash
-# 全部三个文件同步更新
-bash scripts/bump-version.sh 0.1.7
+bash scripts/bump-version.sh X.Y.Z
+bash skills/invest-A/scripts/check-version.sh
 ```
 
-脚本会自动完成全部替换，并提示 git commit / tag 的下一步命令。运行后务必执行分支重命名（如当前分支是 `feat/v0.1.5`，重命名为 `feat/v0.1.6`）。
+运行 bump 后务必执行分支重命名（如当前分支是 `feat/v0.1.5`，重命名为 `feat/v0.1.6`）。
+
+版本一致性仅在发布/CI 时校验（`check-version.sh`），**不在 Skill 运行时或 SessionStart 钩子中执行**。
 
 ## 运行命令
 
@@ -173,4 +175,4 @@ uv run python -c "..." 2>&1 | grep -vE '^[0-9]+%\|'
 ## 报告路径
 
 - 数据源扩展方案：`code/reports/A股数据源扩展研究报告_v0.1.3.md`
-- 个股报告：`code/reports/{symbol}-{name}-{date}.md`
+- 个股报告：`code/reports/{symbol}-{name}/{date}.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,26 @@ diff         # 对比两次快照
 store list   # 历史采集记录
 ```
 
+## pip 规范
+
+**永远不要在项目目录下直接运行 `pip install`** — `pip` 指向的是 Homebrew 全局 Python（`/opt/homebrew`），安装的包会污染系统环境，而且 `.venv` 里反而没有。
+
+正确的操作：
+
+| 场景 | 命令 |
+|------|------|
+| 安装/同步项目依赖 | `uv sync`（自动根据 `pyproject.toml` + `uv.lock` 同步） |
+| 添加新依赖 | 编辑 `pyproject.toml` 的 `dependencies`，然后 `uv sync` |
+| 查看已安装包 | `uv run python -m pip list` |
+| 临时运行脚本 | `uv run python script.py` |
+| 激活 .venv 后使用 pip | `source .venv/bin/activate && pip list` |
+
+验证 .venv 是否生效：
+```bash
+uv run python -c "import sys; print(sys.executable)"
+# 应输出 .../.venv/bin/python3，而不是 /opt/homebrew/...
+```
+
 ## 数据源
 
 | 源 | 状态 | 注意 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — invest-A 投研助手
 
-> 当前版本：v0.1.6 | 分支：feat/v0.1.6
+> 当前版本：v0.1.7 | 分支：feat/v0.1.7
 
 ## 版本规则
 
@@ -15,7 +15,7 @@
 
 ```bash
 # 全部三个文件同步更新
-bash scripts/bump-version.sh 0.1.6
+bash scripts/bump-version.sh 0.1.7
 ```
 
 脚本会自动完成全部替换，并提示 git commit / tag 的下一步命令。运行后务必执行分支重命名（如当前分支是 `feat/v0.1.5`，重命名为 `feat/v0.1.6`）。

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,8 +25,9 @@ Built by [@veblin](https://github.com/veblin) — an investment learner who want
 ### Cutting a release
 
 1. 在 `CHANGELOG.md` 写好 `## vX.Y.Z` 章节（Release 正文从此提取）
-2. 同步四处版本号：`SKILL.md`、`pyproject.toml`、`.claude-plugin/plugin.json`、`gemini-extension.json`
-3. **合并到 `main`** → [Release Draft Notes](.github/workflows/release-draft.yml) 自动根据 `pyproject.toml` 版本创建/更新 **Draft Release**（正文来自 CHANGELOG）
+2. 运行 `bash scripts/bump-version.sh X.Y.Z`（同步 pyproject + SKILL + plugin + marketplace + gemini 共 5 文件）
+3. **合并到 `main`** 前可选：`INVEST_RUN_E2E=1 uv run pytest skills/invest-A/tests/test_v017_e2e.py -v`（四标的 live 冒烟）
+4. **合并到 `main`** → [Release Draft Notes](.github/workflows/release-draft.yml) 自动根据 `pyproject.toml` 版本创建/更新 **Draft Release**（正文来自 CHANGELOG）
 4. 确认 Draft 内容后打 tag：`git tag vX.Y.Z && git push origin vX.Y.Z`
 5. [Release workflow](.github/workflows/release.yml) 打包 tarball 并**正式发布**（`draft: false`）
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ pyproject.toml              ← uv 依赖
 ```bash
 uv sync && uv run pytest
 uv run python skills/invest-A/scripts/invest.py diagnose
-bash skills/invest-A/scripts/check-version.sh   # 版本四件套一致性
+bash skills/invest-A/scripts/check-version.sh   # 分发 manifest（5 文件）版本一致性
 ```
 
 提交前确保测试通过，无 API Key 泄露。

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "invest-A-skill",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "A股多因子投研助手 — 九模块研究备忘录，带数据引用的 Markdown 报告。研究工具，非决策工具。",
   "settings": [
     {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,10 +7,6 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT:-${extensionPath:-.}}/hooks/scripts/check-config.sh\""
-          },
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-${extensionPath:-.}}/skills/invest-A/scripts/check-version.sh\" || true"
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
 testpaths = ["skills/invest-A/tests"]
 python_files = ["test_*.py"]
 addopts = ["-q", "--tb=short"]
+markers = [
+    "e2e: live network collect/report smoke (requires INVEST_RUN_E2E=1)",
+]
 
 [tool.coverage.run]
 source = ["skills/invest-A/scripts"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "investment-learning-skill"
-version = "0.1.6"
+version = "0.1.7"
 description = "A股个股调研多因子投研助手 — Tushare + FRED 数据采集，产出带来源追溯的 Markdown 研究备忘录"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,77 +3,38 @@
 # bump-version.sh — invest-A 批量版本号更新工具
 #
 # 用法:
-#   bash scripts/bump-version.sh 0.1.6
+#   bash scripts/bump-version.sh 0.1.8
 #
-# 作用: 一次性更新以下文件的版本号，保证一致性：
-#   - skills/invest-A/SKILL.md  (frontmatter version:)
-#   - CLAUDE.md                 (当前版本：vX.Y.Z)
-#   - pyproject.toml            (version = "X.Y.Z")
-#   - render.py 从 pyproject.toml 动态读取，无需手动更新
+# canonical: pyproject.toml
+# 同步更新 5 个文件（由 scripts/version_sync.py 执行）：
+#   - pyproject.toml
+#   - skills/invest-A/SKILL.md (frontmatter version:)
+#   - .claude-plugin/plugin.json
+#   - .claude-plugin/marketplace.json (plugins[0].version)
+#   - gemini-extension.json
 # ============================================================
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
     echo "用法: bash scripts/bump-version.sh <新版本号>"
-    echo "示例: bash scripts/bump-version.sh 0.1.6"
+    echo "示例: bash scripts/bump-version.sh 0.1.8"
     exit 1
 fi
 
 NEW_VER="$1"
 
-# 验证版本号格式: X.Y.Z (纯数字)
 if ! echo "$NEW_VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     echo "❌ 版本号格式错误: $NEW_VER"
-    echo "   预期格式: X.Y.Z (例如 0.1.6)"
+    echo "   预期格式: X.Y.Z (例如 0.1.8)"
     exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR/.."
 
-SKILL_FILE="$REPO_ROOT/skills/invest-A/SKILL.md"
-CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
-PYPROJECT_FILE="$REPO_ROOT/pyproject.toml"
-
-# ---- 逐文件更新 ----
-UPDATED=0
-
-# 1. SKILL.md — frontmatter version: "X.Y.Z" 或 version: X.Y.Z
-if [[ -f "$SKILL_FILE" ]]; then
-    sed -i.bak -E 's/^(version[[:space:]]*:[[:space:]]*"?)[0-9]+\.[0-9]+\.[0-9]+("?)/\1'"$NEW_VER"'\2/' "$SKILL_FILE"
-    rm -f "$SKILL_FILE.bak"
-    echo "  ✅ SKILL.md"
-    UPDATED=$((UPDATED + 1))
-else
-    echo "  ⏭️ SKILL.md 不存在"
-fi
-
-# 2. CLAUDE.md — 当前版本：vX.Y.Z | 分支：feat/vX.Y.Z (两处同时更新)
-if [[ -f "$CLAUDE_FILE" ]]; then
-    sed -i.bak -E \
-      -e 's/(当前版本：)v[0-9]+\.[0-9]+\.[0-9]+/\1v'"$NEW_VER"'/' \
-      -e "s|(分支：feat/)v[0-9]+\.[0-9]+\.[0-9]+|\1v$NEW_VER|" \
-      "$CLAUDE_FILE"
-    rm -f "$CLAUDE_FILE.bak"
-    echo "  ✅ CLAUDE.md (版本+分支)"
-    UPDATED=$((UPDATED + 1))
-else
-    echo "  ⏭️ CLAUDE.md 不存在"
-fi
-
-# 3. pyproject.toml — version = "X.Y.Z"
-if [[ -f "$PYPROJECT_FILE" ]]; then
-    sed -i.bak -E 's/^(version[[:space:]]*=[[:space:]]*")[0-9]+\.[0-9]+\.[0-9]+(")/\1'"$NEW_VER"'\2/' "$PYPROJECT_FILE"
-    rm -f "$PYPROJECT_FILE.bak"
-    echo "  ✅ pyproject.toml"
-    UPDATED=$((UPDATED + 1))
-else
-    echo "  ⏭️ pyproject.toml 不存在"
-fi
-
-echo ""
-if [[ "$UPDATED" -eq 3 ]]; then
-    echo "✅ 版本已全部更新为 v${NEW_VER}"
+cd "$REPO_ROOT"
+echo "更新版本号为 v${NEW_VER} ..."
+if uv run python scripts/version_sync.py bump "$NEW_VER"; then
     echo ""
     echo "下一步:"
     echo "  1. git checkout -b feat/v${NEW_VER}  # 新建分支（或重命名当前分支）"
@@ -81,6 +42,5 @@ if [[ "$UPDATED" -eq 3 ]]; then
     echo "  3. git tag v${NEW_VER}"
     echo "  4. git push && git push --tags"
 else
-    echo "⚠️ 部分更新 (${UPDATED}/3)"
     exit 1
 fi

--- a/scripts/version_sync.py
+++ b/scripts/version_sync.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Centralized invest-A product version sync (canonical: pyproject.toml)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+_JSON_VERSION_LINE_RE = re.compile(
+    r'^(\s*"version"\s*:\s*")[0-9]+\.[0-9]+\.[0-9]+(")'
+)
+_JSON_VERSION_VALUE_RE = re.compile(
+    r'("version"\s*:\s*")[0-9]+\.[0-9]+\.[0-9]+(")'
+)
+_MARKETPLACE_PLUGIN_NAME = "invest-A"
+
+
+@dataclass(frozen=True)
+class VersionTarget:
+    rel_path: str
+    label: str
+    canonical: bool = False
+
+
+TARGETS: tuple[VersionTarget, ...] = (
+    VersionTarget("pyproject.toml", "pyproject.toml", canonical=True),
+    VersionTarget("skills/invest-A/SKILL.md", "SKILL.md"),
+    VersionTarget(".claude-plugin/plugin.json", "plugin.json"),
+    VersionTarget(".claude-plugin/marketplace.json", "marketplace.json"),
+    VersionTarget("gemini-extension.json", "gemini-extension.json"),
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def validate_version(version: str) -> None:
+    if not VERSION_RE.match(version):
+        raise ValueError(f"invalid version format: {version!r} (expected X.Y.Z)")
+
+
+def read_pyproject_version(path: Path) -> str:
+    in_project = False
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line == "[project]":
+            in_project = True
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_project = line == "[project]"
+            continue
+        if in_project and line.startswith("version") and "=" in line:
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    raise ValueError(f"no [project].version in {path}")
+
+
+def write_pyproject_version(path: Path, version: str) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    in_project = False
+    updated = False
+    out: list[str] = []
+    for raw in lines:
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        if stripped == "[project]":
+            in_project = True
+            out.append(raw)
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project = stripped == "[project]"
+            out.append(raw)
+            continue
+        if in_project and stripped.startswith("version") and "=" in stripped:
+            prefix = raw.split("=", 1)[0]
+            out.append(f'{prefix}= "{version}"\n')
+            updated = True
+            continue
+        out.append(raw)
+    if not updated:
+        raise ValueError(f"could not update version in {path}")
+    path.write_text("".join(out), encoding="utf-8")
+
+
+def read_skill_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise ValueError(f"no YAML frontmatter in {path}")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise ValueError(f"unclosed YAML frontmatter in {path}")
+    frontmatter = text[3:end]
+    for raw in frontmatter.splitlines():
+        if raw.strip().startswith("version:"):
+            value = raw.split(":", 1)[1].strip().strip('"').strip("'")
+            if value:
+                return value
+    raise ValueError(f"no version: in SKILL frontmatter ({path})")
+
+
+def write_skill_version(path: Path, version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise ValueError(f"no YAML frontmatter in {path}")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise ValueError(f"unclosed YAML frontmatter in {path}")
+    frontmatter = text[3:end]
+    rest = text[end:]
+    lines = frontmatter.splitlines()
+    updated = False
+    new_lines: list[str] = []
+    for line in lines:
+        if line.strip().startswith("version:"):
+            indent = line[: len(line) - len(line.lstrip())]
+            new_lines.append(f'{indent}version: "{version}"')
+            updated = True
+        else:
+            new_lines.append(line)
+    if not updated:
+        raise ValueError(f"no version: in SKILL frontmatter ({path})")
+    path.write_text("---\n" + "\n".join(new_lines) + rest, encoding="utf-8")
+
+
+def _marketplace_plugin_version(data: dict) -> str:
+    plugins = data.get("plugins")
+    if not isinstance(plugins, list):
+        raise ValueError("marketplace.json missing plugins array")
+    for plugin in plugins:
+        if isinstance(plugin, dict) and plugin.get("name") == _MARKETPLACE_PLUGIN_NAME:
+            version = plugin.get("version")
+            if isinstance(version, str) and version:
+                return version
+    raise ValueError(
+        f'marketplace.json has no plugin named "{_MARKETPLACE_PLUGIN_NAME}"'
+    )
+
+
+def read_json_version(path: Path, rel_path: str) -> str:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if rel_path == ".claude-plugin/marketplace.json":
+        return _marketplace_plugin_version(data)
+    version = data.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"invalid top-level version in {path}")
+    return version
+
+
+def _patch_json_version_lines(text: str, version: str, *, marketplace: bool) -> str:
+    lines = text.splitlines(keepends=True)
+    in_target_plugin = False
+    updated = False
+    out: list[str] = []
+    plugin_name_re = re.compile(
+        rf'"name"\s*:\s*"{re.escape(_MARKETPLACE_PLUGIN_NAME)}"'
+    )
+    for line in lines:
+        if marketplace and plugin_name_re.search(line):
+            in_target_plugin = True
+            if _JSON_VERSION_VALUE_RE.search(line):
+                line = _JSON_VERSION_VALUE_RE.sub(rf"\g<1>{version}\2", line, count=1)
+                updated = True
+                in_target_plugin = False
+                out.append(line)
+                continue
+        elif marketplace and in_target_plugin and re.search(r'"name"\s*:', line):
+            in_target_plugin = False
+        if _JSON_VERSION_LINE_RE.match(line.rstrip("\n")):
+            if not marketplace or in_target_plugin:
+                line = _JSON_VERSION_LINE_RE.sub(rf"\g<1>{version}\2", line, count=1)
+                updated = True
+                if marketplace:
+                    in_target_plugin = False
+        out.append(line)
+    if not updated:
+        scope = "marketplace plugin" if marketplace else "top-level"
+        raise ValueError(f"could not update {scope} version in file")
+    return "".join(out)
+
+
+def write_json_version(path: Path, rel_path: str, version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    marketplace = rel_path == ".claude-plugin/marketplace.json"
+    patched = _patch_json_version_lines(text, version, marketplace=marketplace)
+    if patched != text:
+        path.write_text(patched, encoding="utf-8")
+
+
+def read_target_version(root: Path, target: VersionTarget) -> str:
+    path = root / target.rel_path
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if target.rel_path == "pyproject.toml":
+        return read_pyproject_version(path)
+    if target.rel_path.endswith("SKILL.md"):
+        return read_skill_version(path)
+    if target.rel_path.endswith(".json"):
+        return read_json_version(path, target.rel_path)
+    raise ValueError(f"unsupported target: {target.rel_path}")
+
+
+def write_target_version(root: Path, target: VersionTarget, version: str) -> None:
+    path = root / target.rel_path
+    if target.rel_path == "pyproject.toml":
+        write_pyproject_version(path, version)
+        return
+    if target.rel_path.endswith("SKILL.md"):
+        write_skill_version(path, version)
+        return
+    if target.rel_path.endswith(".json"):
+        write_json_version(path, target.rel_path, version)
+        return
+    raise ValueError(f"unsupported target: {target.rel_path}")
+
+
+def read_canonical_version(root: Path | None = None) -> str:
+    root = root or repo_root()
+    canonical = next(t for t in TARGETS if t.canonical)
+    return read_target_version(root, canonical)
+
+
+def cmd_show(root: Path) -> int:
+    print(read_canonical_version(root))
+    return 0
+
+
+def cmd_check(root: Path) -> int:
+    canonical_target = next(t for t in TARGETS if t.canonical)
+    try:
+        canonical = read_target_version(root, canonical_target)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"❌ cannot read canonical version from {canonical_target.rel_path}: {exc}", file=sys.stderr)
+        return 1
+
+    mismatches: list[str] = []
+    report: list[str] = []
+    for target in TARGETS:
+        try:
+            found = read_target_version(root, target)
+        except (OSError, ValueError, json.JSONDecodeError, FileNotFoundError) as exc:
+            print(f"❌ cannot read {target.rel_path}: {exc}", file=sys.stderr)
+            return 1
+        suffix = " (canonical)" if target.canonical else f" (expected {canonical})"
+        report.append(f"{target.label}={found}{suffix}")
+        if found != canonical:
+            mismatches.append(f"  {target.rel_path}: {found} != {canonical}")
+
+    if mismatches:
+        print("⚠️ invest-A version mismatch:")
+        for line in report:
+            print(f"  {line}")
+        for line in mismatches:
+            print(line)
+        print(f"❌ fix: bash scripts/bump-version.sh {canonical}")
+        return 1
+
+    print(
+        "✅ invest-A versions consistent: "
+        + ", ".join(f"{t.label}={canonical}" for t in TARGETS)
+    )
+    return 0
+
+
+def cmd_bump(root: Path, version: str) -> int:
+    validate_version(version)
+    backups: list[tuple[Path, str]] = []
+    written: list[Path] = []
+    try:
+        for target in TARGETS:
+            path = root / target.rel_path
+            if not path.exists():
+                raise FileNotFoundError(path)
+            backups.append((path, path.read_text(encoding="utf-8")))
+            write_target_version(root, target, version)
+            written.append(path)
+            print(f"  ✅ {target.label}")
+    except (OSError, ValueError, FileNotFoundError) as exc:
+        for path, content in reversed(backups):
+            if path in written:
+                path.write_text(content, encoding="utf-8")
+        print(f"❌ bump failed, rolled back: {exc}", file=sys.stderr)
+        return 1
+
+    if len(written) == len(TARGETS):
+        print(f"\n✅ all {len(written)} version files updated to v{version}")
+        return 0
+    print(f"⚠️ partial update ({len(written)}/{len(TARGETS)})", file=sys.stderr)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="invest-A version sync utilities")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="repository root (default: parent of scripts/)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("show", help="print canonical version from pyproject.toml")
+    sub.add_parser("check", help="verify all version targets match canonical")
+    bump_p = sub.add_parser("bump", help="write version to all targets")
+    bump_p.add_argument("version", help="new version X.Y.Z")
+
+    args = parser.parse_args(argv)
+    root = (args.root or repo_root()).resolve()
+
+    if args.command == "show":
+        return cmd_show(root)
+    if args.command == "check":
+        return cmd_check(root)
+    if args.command == "bump":
+        try:
+            validate_version(args.version)
+        except ValueError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            return 1
+        return cmd_bump(root, args.version)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/invest-A/SKILL.md
+++ b/skills/invest-A/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-A
-version: "0.1.6"
+version: "0.1.7"
 description: "A股多因子交叉验证的结构化投研助手 — 数据采集 + 学术级引用，产出带来源追溯的 Markdown 研究备忘录。研究工具，非决策工具。"
 argument-hint: "/invest-A 600176 | /invest-A 600176 --with-macro | /invest-A 600176 --deep | /invest-A 600176 --compare 000858"
 allowed-tools: Bash, Read, Write, WebSearch, WebFetch

--- a/skills/invest-A/SKILL.md
+++ b/skills/invest-A/SKILL.md
@@ -16,21 +16,6 @@ metadata:
 
 # invest-A 投研助手
 
-## Step 0: 版本自检
-
-每次 invoke 本 Skill 时，运行以下检查：
-
-1. 检查 `skills/invest-A/scripts/check-version.sh` 是否存在
-2. 若存在，执行 `bash skills/invest-A/scripts/check-version.sh`
-3. 若版本不一致（exit code ≠ 0），输出警告并建议更新：
-   `⚠️ invest-A 版本不匹配，请运行 git pull 更新`
-4. 若从缓存路径加载（exit code = 2），拒绝执行：
-   `⛔ 检测到从缓存路径加载，请通过 /plugin 重新安装`
-5. 若无 shell 脚本（非 shell 环境），读取 SKILL.md 第一行 frontmatter 的 `version:` 字段
-6. 将版本号与 CLAUDE.md 中的 `当前版本：v` 行对比
-
----
-
 ## OUTPUT CONTRACT（LAWs）
 
 以下法则约束所有输出。违反即为 Bug。
@@ -100,7 +85,7 @@ metadata:
 
 - **LAW 6 相关**：禁止出现"买入""卖出""持有""建仓""加仓""减仓""目标价""止损""止盈"等直接或暗示性表述。可使用"市场定价区间""历史估值分位""多源均值对比"等描述。
 - **版本号**：最多三位 `v{major}.{minor}.{patch}`，功能变更递增末位。同版本内修订用日期区分。
-- **报告路径**：详细文档写入 `code/reports/{symbol}-{name}-{date}.md`，Claude 内只输出简报。
+- **报告路径**：详细文档写入 `code/reports/{symbol}-{name}/{date}.md`，Claude 内只输出简报。
 
 ### 数据源策略（v0.2 → v0.3 变更）
 
@@ -154,7 +139,7 @@ Claude 对话中输出的内容须精简为**可一目扫完**的简报，核心
 
 ### 第二层：.md 详细文档（完整研究备忘录）
 
-详细分析内容须写入 `code/reports/{symbol}-{name}-{date}.md` 文件。
+详细分析内容须写入 `code/reports/{symbol}-{name}/{date}.md` 文件。
 - 包含完整九模块（或八段 legacy）全部内容
 - 包含引用来源表（References，见本文件附录规范）
 - 包含完整技术指标计算表
@@ -173,7 +158,7 @@ Claude 对话中输出的内容须精简为**可一目扫完**的简报，核心
 
 **结构检查：**
 - [ ] Claude 内简报已压缩至 3-5 段（不在对话中展开全部九模块）
-- [ ] 详细报告已写入 `code/reports/{symbol}-{name}-{date}.md`
+- [ ] 详细报告已写入 `code/reports/{symbol}-{name}/{date}.md`
 - [ ] 风险提示在首尾部（LAW 4）
 - [ ] 每个数字有追溯路径（LAW 7）
 
@@ -376,3 +361,14 @@ rules:
 - akshare：标注 `ak.{函数名}(参数...)`
 - 腾讯行情：标注 `qt.gtimg.cn` + 请求 URL
 - baostock：标注 `bs.query_history_k_data_plus(...)`
+
+### WebSearch 白名单（涨价信号触发）
+
+当 `industry_pricing` 维度涨价信号为「确认」时，WebSearch 深搜应优先限定以下域名（完整列表见 `env.PRICE_NEWS_WHITELIST`）：
+
+```
+site:stcn.com OR site:cnstock.com OR site:cs.com.cn OR site:21jingji.com
+OR site:eeo.com.cn OR site:finance.sina.com.cn OR site:10jqka.com.cn OR site:cls.cn
+```
+
+> ⚠️ 东方财富 (eastmoney.com) 因代理问题暂不列入白名单。

--- a/skills/invest-A/scripts/check-version.sh
+++ b/skills/invest-A/scripts/check-version.sh
@@ -3,14 +3,13 @@ set -euo pipefail
 
 # ============================================================
 # check-version.sh — invest-A 版本一致性检查
-# 用途：检查 SKILL.md / CLAUDE.md / pyproject.toml 版本一致性
-#       并检测 SKILL.md 是否从缓存路径加载
+# canonical: pyproject.toml
+# 校验 5 个分发 manifest 版本一致，并检测 SKILL.md 缓存路径
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-# ---- 参数解析 ----
 SKILL_FILE=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -30,36 +29,8 @@ if [[ -z "$SKILL_FILE" ]]; then
     SKILL_FILE="$REPO_ROOT/skills/invest-A/SKILL.md"
 fi
 
-CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
-PYPROJECT_FILE="$REPO_ROOT/pyproject.toml"
-
-# ---- 辅助函数：从文件提取版本 ----
-extract_version_skill() {
-    local f="$1"
-    # 匹配 YAML frontmatter 中的 version: "x.y.z" 或 version: x.y.z
-    sed -n '/^---$/,/^---$/p' "$f" 2>/dev/null \
-        | grep -E '^version[[:space:]]*:' \
-        | sed -E 's/^version[[:space:]]*:[[:space:]]*"?([^"]*)"?/\1/'
-}
-
-extract_version_claude() {
-    local f="$1"
-    # 匹配 当前版本：vX.Y.Z
-    grep -E '当前版本：v[0-9]+\.[0-9]+\.[0-9]+' "$f" 2>/dev/null \
-        | sed -E 's/.*当前版本：v([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
-}
-
-extract_version_pyproject() {
-    local f="$1"
-    # 匹配 version = "x.y.z"
-    grep -E '^version[[:space:]]*=' "$f" 2>/dev/null \
-        | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]*)"/\1/'
-}
-
-# ---- 检测缓存路径 ----
 check_cache_path() {
     local skill_path="$1"
-    # 规范化路径，展开所有 ..
     local resolved
     resolved="$(cd "$(dirname "$skill_path")" && pwd)/$(basename "$skill_path")"
     if echo "$resolved" | grep -qF '/.claude/plugins/cache/'; then
@@ -69,37 +40,12 @@ check_cache_path() {
     fi
 }
 
-# ---- 主逻辑 ----
-
-# 检查文件是否存在
-for f in "$SKILL_FILE" "$CLAUDE_FILE"; do
-    if [[ ! -f "$f" ]]; then
-        echo "❌ 文件不存在: $f" >&2
-        exit 1
-    fi
-done
-
-V_SKILL="$(extract_version_skill "$SKILL_FILE")"
-V_CLAUDE="$(extract_version_claude "$CLAUDE_FILE")"
-
-if [[ -z "$V_SKILL" ]]; then
-    echo "❌ 无法从 SKILL.md 解析 version（检查 frontmatter 中的 version: 字段）" >&2
-    exit 1
-fi
-if [[ -z "$V_CLAUDE" ]]; then
-    echo "❌ 无法从 CLAUDE.md 解析版本（期望行：当前版本：vX.Y.Z）" >&2
+if [[ ! -f "$SKILL_FILE" ]]; then
+    echo "❌ 文件不存在: $SKILL_FILE" >&2
     exit 1
 fi
 
-if [[ -f "$PYPROJECT_FILE" ]]; then
-    V_PYPROJECT="$(extract_version_pyproject "$PYPROJECT_FILE")"
-else
-    V_PYPROJECT=""
-fi
-
-# 检查是否从缓存加载
 CACHE_STATUS="$(check_cache_path "$SKILL_FILE")"
-
 if [[ "$CACHE_STATUS" == "cache" ]]; then
     echo "⛔ invest-A 从缓存路径加载 SKILL.md"
     echo "   路径: $(cd "$(dirname "$SKILL_FILE")" && pwd)/$(basename "$SKILL_FILE")"
@@ -107,40 +53,9 @@ if [[ "$CACHE_STATUS" == "cache" ]]; then
     exit 2
 fi
 
-# 版本一致性检查
-MISMATCH=0
-REPORT_LINES=()
-
-append_report() {
-    REPORT_LINES+=("$1")
-}
-
-append_report "SKILL.md=${V_SKILL}"
-append_report "CLAUDE.md=${V_CLAUDE} (预期 ${V_SKILL})"
-if [[ -n "$V_PYPROJECT" ]]; then
-    append_report "pyproject.toml=${V_PYPROJECT}"
-fi
-
-if [[ "$V_SKILL" != "$V_CLAUDE" ]]; then
-    MISMATCH=1
-fi
-if [[ -n "$V_PYPROJECT" && "$V_SKILL" != "$V_PYPROJECT" ]]; then
-    MISMATCH=1
-fi
-
-if [[ "$MISMATCH" -eq 0 ]]; then
-    if [[ -n "$V_PYPROJECT" ]]; then
-        echo "✅ invest-A 版本一致: SKILL.md=${V_SKILL}, CLAUDE.md=${V_CLAUDE}, pyproject.toml=${V_PYPROJECT}"
-    else
-        echo "✅ invest-A 版本一致: SKILL.md=${V_SKILL}, CLAUDE.md=${V_CLAUDE}"
-    fi
+cd "$REPO_ROOT"
+if uv run python scripts/version_sync.py check; then
     echo "✅ SKILL.md 从正常路径加载"
     exit 0
-else
-    echo "⚠️ invest-A 版本不一致:"
-    for line in "${REPORT_LINES[@]}"; do
-        echo "  $line"
-    done
-    echo "❌ 修复方法：bash scripts/bump-version.sh ${V_SKILL}  # 统一更新三个文件的版本号"
-    exit 1
 fi
+exit 1

--- a/skills/invest-A/scripts/invest.py
+++ b/skills/invest-A/scripts/invest.py
@@ -35,7 +35,10 @@ while _project_root != _project_root.parent:
     _project_root = _project_root.parent
 
 from lib import collector, env, render
+from lib.collector import _DEFAULT_DIMS
 from lib.proxy import warn_if_proxy_detected
+
+_CLI_DEFAULT_DIMS = ",".join(_DEFAULT_DIMS)
 
 try:
     from lib import store as store_mod
@@ -261,7 +264,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     pc = sub.add_parser("collect", help="采集多维度数据")
     pc.add_argument("symbol")
-    pc.add_argument("--dims", default="basic_info,financials,quote,shareholders,northbound,valuation,kline")
+    pc.add_argument("--dims", default=_CLI_DEFAULT_DIMS)
     pc.add_argument("--store", action="store_true", help="存入持久化存储")
     pc.add_argument("--with-macro", action="store_true", help="采集中国宏观指标（PMI/CPI/PPI/LPR，akshare）")
     pc.add_argument("--deep", action="store_true", help="深度模式：K线窗口从默认 400 天（~1.1年）扩展至 730 天（2年），增加行业/产业链分析 + 自动采集机构研报")
@@ -269,7 +272,7 @@ def build_parser() -> argparse.ArgumentParser:
     pr = sub.add_parser("report", help="生成分析报告")
     pr.add_argument("symbol")
     pr.add_argument("--emit", default="md", choices=["compact", "json", "md", "html"])
-    pr.add_argument("--dims", default="basic_info,financials,quote,shareholders,northbound,valuation,kline")
+    pr.add_argument("--dims", default=_CLI_DEFAULT_DIMS)
     pr.add_argument("--with-macro", action="store_true", help="采集中国宏观指标（PMI/CPI/PPI/LPR，akshare）")
     pr.add_argument("--deep", action="store_true", help="深度模式：K线窗口从默认 400 天（~1.1年）扩展至 730 天（2年），增加行业/产业链分析 + 自动采集机构研报")
     pr.add_argument("--outdir", default="", help="报告输出目录（指定则写 .md 或 .html 文件；默认仅 stdout）")
@@ -315,7 +318,7 @@ def build_parser() -> argparse.ArgumentParser:
     pe = sub.add_parser("evidence", help="生成结构化证据表")
     pe.add_argument("symbol")
     pe.add_argument("--emit", default="md", choices=["md", "json"])
-    pe.add_argument("--dims", default="basic_info,financials,quote,shareholders,northbound,valuation,kline")
+    pe.add_argument("--dims", default=_CLI_DEFAULT_DIMS)
     _add_collect_flags(pe)
 
     pa = sub.add_parser("analyze", help="分析采集结果（输出中间分析 JSON）")
@@ -330,6 +333,7 @@ def build_parser() -> argparse.ArgumentParser:
     psyn.add_argument("--emit", default="md", choices=["md", "json"])
     psyn.add_argument("--mode", default="full", choices=["brief", "full"])
     psyn.add_argument("--outdir", default="", help="报告输出目录")
+    psyn.add_argument("--dims", default=_CLI_DEFAULT_DIMS)
     _add_collect_flags(psyn)
 
     pp = sub.add_parser(
@@ -409,7 +413,7 @@ def cmd_collect(args: argparse.Namespace) -> int:
 
 
 def _report_basename(result: dict, symbol: str, ts: str) -> str:
-    """生成报告文件名前缀：{ts}-{symbol}-{name}。"""
+    """生成报告子目录名：{symbol}-{name}（文件名用日期，如 2026-07-05.md）。"""
     name = ""
     for dim in result.get("dimensions", []):
         if dim.get("dimension") == "basic_info":
@@ -418,7 +422,15 @@ def _report_basename(result: dict, symbol: str, ts: str) -> str:
                 name = data.get("name", "") or data.get("股票简称", "")
             break
     safe_name = re.sub(r'[\\/:*?"<>|]', "_", name) if name else ""
-    return f"{ts}-{symbol}-{safe_name}" if safe_name else f"{ts}-{symbol}"
+    return f"{symbol}-{safe_name}" if safe_name else symbol
+
+
+def _report_filepath(outdir: Path, subdir: str, ts: str) -> Path:
+    """生成报告完整路径：{outdir}/{subdir}/{date}.md。"""
+    date = ts[:10]  # 仅日期部分，如 2026-07-05
+    report_dir = outdir / subdir
+    report_dir.mkdir(parents=True, exist_ok=True)
+    return report_dir / f"{date}.md"
 
 
 def cmd_report(args: argparse.Namespace) -> int:
@@ -468,13 +480,13 @@ def cmd_report(args: argparse.Namespace) -> int:
         now = datetime.now()
         ts = now.strftime("%Y-%m-%d-%H-%M-%S")
 
-        basename = _report_basename(result, args.symbol, ts)
+        subdir = _report_basename(result, args.symbol, ts)
         outdir = Path(args.outdir).resolve() if args.outdir else Path.cwd()
-        outdir.mkdir(parents=True, exist_ok=True)
-        htmlpath = outdir / f"{basename}.html"
+        htmlpath = _report_filepath(outdir, subdir, ts).with_suffix(".html")
+        htmlpath.parent.mkdir(parents=True, exist_ok=True)
         htmlpath.write_text(output, encoding="utf-8")
 
-        mdfile = outdir / f"{basename}.md"
+        mdfile = _report_filepath(outdir, subdir, ts)
         mdfile.write_text(md_v2, encoding="utf-8")
 
         print(render.render(result, args.symbol, "compact"))
@@ -496,10 +508,9 @@ def cmd_report(args: argparse.Namespace) -> int:
     if fmt == "md" and args.outdir:
         from datetime import datetime
         ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        basename = _report_basename(result, args.symbol, ts)
+        subdir = _report_basename(result, args.symbol, ts)
         outdir = Path(args.outdir).resolve()
-        outdir.mkdir(parents=True, exist_ok=True)
-        mdpath = outdir / f"{basename}.md"
+        mdpath = _report_filepath(outdir, subdir, ts)
         mdpath.write_text(output, encoding="utf-8")
         print(f"📝 Markdown 报告: {mdpath.resolve()}")
         return 0
@@ -507,8 +518,8 @@ def cmd_report(args: argparse.Namespace) -> int:
     if fmt == "md":
         from datetime import datetime
         ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        basename = _report_basename(result, args.symbol, ts)
-        htmlpath = Path.cwd() / f"{basename}.html"
+        subdir = _report_basename(result, args.symbol, ts)
+        htmlpath = Path.cwd() / f"{subdir}-{ts[:10]}.html"
         try:
             html_out = render.render_html(result, args.symbol)
             htmlpath.write_text(html_out, encoding="utf-8")
@@ -647,10 +658,7 @@ def cmd_analyze(args: argparse.Namespace) -> int:
             print(f"❌ 无法读取输入文件: {exc}", file=sys.stderr)
             return 1
     else:
-        dims = _apply_deep_dims([
-            "basic_info", "financials", "quote", "shareholders",
-            "northbound", "valuation", "kline",
-        ], getattr(args, "deep", False))
+        dims = _apply_deep_dims(list(_DEFAULT_DIMS), getattr(args, "deep", False))
         result = collector.collect_all(args.symbol, dims, **_collect_kwargs(args))
 
     if result.get("summary", {}).get("available", 0) == 0:
@@ -737,10 +745,7 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
                 "ⓘ analyze 输出缺少 dimensions，将补充现场采集",
                 file=sys.stderr,
             )
-            dims = _apply_deep_dims([
-                "basic_info", "financials", "quote", "shareholders",
-                "northbound", "valuation", "kline",
-            ], getattr(args, "deep", False))
+            dims = _apply_deep_dims(list(_DEFAULT_DIMS), getattr(args, "deep", False))
             result = collector.collect_all(
                 args.symbol, dims, **_collect_kwargs(args),
             )
@@ -764,25 +769,21 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
         if fmt == "md" and args.outdir:
             from datetime import datetime
             ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-            basename = _report_basename(result, args.symbol, ts)
+            subdir = _report_basename(result, args.symbol, ts)
             outdir = Path(args.outdir).resolve()
-            outdir.mkdir(parents=True, exist_ok=True)
-            mdpath = outdir / f"{basename}.md"
+            mdpath = _report_filepath(outdir, subdir, ts)
             mdpath.write_text(output, encoding="utf-8")
             print(f"📝 Markdown 报告: {mdpath.resolve()}")
             return 0
         print(output)
         return 0
 
-    # 设置 cmd_report 所需的缺省属性
-    if not hasattr(args, 'dims'):
-        args.dims = "basic_info,financials,quote,shareholders,northbound,valuation,kline"
-    if not hasattr(args, 'with_macro'):
+    # 无 --input 时委托 cmd_report（dims 由 parser 默认 _CLI_DEFAULT_DIMS）
+    if not hasattr(args, "with_macro"):
         args.with_macro = False
-    if not hasattr(args, 'deep'):
+    if not hasattr(args, "deep"):
         args.deep = False
 
-    # 委托给 cmd_report 逻辑
     return cmd_report(args)
 
 

--- a/skills/invest-A/scripts/lib/chain.py
+++ b/skills/invest-A/scripts/lib/chain.py
@@ -29,6 +29,19 @@ _CHAIN_MAP: dict[str, dict[str, Any]] = {
     "电子": {"position": "中游制造", "upstream": ["硅", "稀土"], "downstream": ["手机", "汽车"]},
 }
 
+# P1-1: 行业 → 期货品种映射（复用 _match_chain_keyword 做长度降序匹配）
+_INDUSTRY_FUTURES_MAP: dict[str, list[tuple[str, str]]] = {
+    "化工":       [("原油", "SC"), ("纯碱", "SA"), ("甲醇", "MA"), ("PTA", "TA"), ("聚丙烯", "PP")],
+    "玻璃":       [("玻璃", "FG"), ("纯碱", "SA")],
+    "玻纤":       [("玻璃", "FG"), ("纯碱", "SA")],
+    "钢铁":       [("铁矿石", "I"), ("螺纹钢", "RB"), ("热卷", "HC"), ("焦炭", "J")],
+    "有色金属":   [("铜", "CU"), ("铝", "AL"), ("锌", "ZN"), ("镍", "NI"), ("锡", "SN")],
+    "煤炭":       [("焦煤", "JM"), ("焦炭", "J"), ("动力煤", "ZC")],
+    "石油石化":   [("原油", "SC"), ("燃料油", "FU"), ("沥青", "BU")],
+    "新能源汽车": [("碳酸锂", "LC"), ("工业硅", "SI")],
+    "造纸":       [("纸浆", "SP")],
+}
+
 _GLOBAL_PEER_MAP: dict[str, list[str]] = {
     "汽车": ["Tesla (TSLA)", "Toyota (TM)", "Volkswagen (VOW3.DE)"],
     "半导体": ["NVIDIA (NVDA)", "TSMC (TSM)", "Intel (INTC)"],
@@ -44,6 +57,16 @@ def _match_chain_keyword(industry: str, mapping: dict) -> Any:
         if keyword in industry:
             return mapping[keyword]
     return None
+
+
+def get_futures_for_industry(industry: str) -> list[tuple[str, str]]:
+    """根据申万行业名称返回应追踪的期货品种列表。
+
+    复用 _match_chain_keyword() 的长度降序匹配，避免"新能源汽车"
+    被"新能源"或"汽车"的映射误命中。
+    """
+    result = _match_chain_keyword(industry, _INDUSTRY_FUTURES_MAP)
+    return result or []
 
 
 def collect_chain_context(

--- a/skills/invest-A/scripts/lib/collector.py
+++ b/skills/invest-A/scripts/lib/collector.py
@@ -242,7 +242,7 @@ def _q_tushare_basic(symbol: str) -> dict | None:
 def _merge_cashflow_into_financials(
     financials: list[dict], cashflow: list[dict],
 ) -> list[dict]:
-    """按 end_date 合并经营现金流，供 CV-1 交叉验证。"""
+    """按 end_date 合并现金流字段（OCF/CapEx），供 DCF/CV-1。"""
     cf_by_date = {str(r.get("end_date", "")): r for r in cashflow}
     out: list[dict] = []
     for row in financials:
@@ -253,6 +253,48 @@ def _merge_cashflow_into_financials(
             if ncf is not None:
                 merged["n_cashflow_act"] = ncf
                 merged["ocf"] = ncf
+            # P0-1: c_pay_acq_const_fiolta → cap_ex（Tushare 实测仅此 Capex 字段可用）
+            capex = cf.get("c_pay_acq_const_fiolta")
+            if capex is not None:
+                merged["cap_ex"] = capex
+        out.append(merged)
+    return out
+
+
+def _merge_income_into_financials(
+    financials: list[dict], income: list[dict],
+) -> list[dict]:
+    """按 end_date 合并利润表明细（EBIT/EBITDA/费用/税金），供 DCF 估值。"""
+    inc_by_date = {str(r.get("end_date", "")): r for r in income}
+    _income_passthrough = (
+        "ebit", "ebitda", "fin_exp", "income_tax",
+        "sell_exp", "admin_exp", "invest_income",
+        "total_profit", "n_income_attr_p",
+    )
+    out: list[dict] = []
+    for row in financials:
+        merged = dict(row)
+        inc = inc_by_date.get(str(row.get("end_date", "")))
+        if inc:
+            for key in _income_passthrough:
+                val = inc.get(key)
+                if val is not None:
+                    merged[key] = val
+            # 别名映射（与计划一致）
+            tax = inc.get("income_tax")
+            if tax is not None:
+                merged["tax"] = tax
+            sell = inc.get("sell_exp")
+            if sell is not None:
+                merged["selling_exp"] = sell
+            # 推导折旧摊销（EBITDA - EBIT，Tushare 无单独 depr/amort 字段）
+            ebit_v = inc.get("ebit")
+            ebitda_v = inc.get("ebitda")
+            if ebit_v is not None and ebitda_v is not None:
+                try:
+                    merged["depr_amort"] = float(ebitda_v) - float(ebit_v)
+                except (TypeError, ValueError):
+                    pass
         out.append(merged)
     return out
 
@@ -260,8 +302,12 @@ def _merge_cashflow_into_financials(
 def _merge_balancesheet_into_financials(
     financials: list[dict], balancesheet: list[dict],
 ) -> list[dict]:
-    """按 end_date 合并应收/存货，供 CV-2 交叉验证。"""
+    """按 end_date 合并资产负债表字段（应收/存货/负债/权益/现金），供 DCF/CV-2。"""
     bs_by_date = {str(r.get("end_date", "")): r for r in balancesheet}
+    _bs_passthrough = (
+        "total_liab", "total_hldr_eqy_inc_min_int", "money_cap",
+        "total_cur_assets", "total_cur_liab", "total_assets",
+    )
     out: list[dict] = []
     for row in financials:
         merged = dict(row)
@@ -277,6 +323,15 @@ def _merge_balancesheet_into_financials(
                 inv = bs.get("inventory")
             if inv is not None:
                 merged["inventory"] = inv
+            # P0-1: 透传 DCF 所需资产负债表字段
+            for key in _bs_passthrough:
+                val = bs.get(key)
+                if val is not None:
+                    merged[key] = val
+            # total_hldr_eqy_inc_min_int 别名 total_equity（与计划一致）
+            eqy = bs.get("total_hldr_eqy_inc_min_int")
+            if eqy is not None:
+                merged["total_equity"] = eqy
         out.append(merged)
     return out
 
@@ -295,7 +350,7 @@ def _q_tushare_financials(symbol: str) -> list[dict] | None:
         fields=(
             "ts_code,end_date,roe,eps,profit_dedt,revenue,net_profit,"
             "grossprofit_margin,netprofit_margin,assets_turn,eqt_to_debt,"
-            "debt_to_assets"
+            "debt_to_assets,ebit,ebitda,fcff,fcfe"
         ),
         start_date=lookback, end_date=end,
     )
@@ -311,15 +366,37 @@ def _q_tushare_financials(symbol: str) -> list[dict] | None:
             if da is not None and 0 <= da <= 100:
                 # Tushare debt_to_assets 为百分比（0-100），如 0.8 表示 0.8%
                 rec["equity_multiplier"] = 1.0 / max(0.01, (100.0 - da) / 100.0)
+    # P0-1: income 查询 — 补齐 DCF 所需费用/利润明细字段
+    inc_df = tc.query("income", ts_code=ts,
+                      fields=(
+                          "ts_code,end_date,ebit,ebitda,fin_exp,income_tax,"
+                          "sell_exp,admin_exp,invest_income,"
+                          "total_profit,n_income_attr_p"
+                      ),
+                      start_date=lookback, end_date=end)
+    if inc_df is not None and not inc_df.empty:
+        records = _merge_income_into_financials(records, inc_df.to_dict("records"))
+    elif inc_df is None or inc_df.empty:
+        logger.warning("Tushare income query returned empty for %s; ebit/ebitda/fin_exp fields will be missing from records", ts)
+    # P0-1: cashflow 扩字段 — 补齐 DCF 所需 CapEx（Tushare 此表无 depr/amort，由 fina_indicator 的 ebitda-ebit 推导）
     cf_df = tc.query("cashflow", ts_code=ts,
-                     fields="ts_code,end_date,n_cashflow_act",
+                     fields=(
+                         "ts_code,end_date,n_cashflow_act,"
+                         "c_pay_acq_const_fiolta"
+                     ),
                      start_date=lookback, end_date=end)
     if cf_df is not None and not cf_df.empty:
         records = _merge_cashflow_into_financials(records, cf_df.to_dict("records"))
     elif cf_df is None or cf_df.empty:
         logger.warning("Tushare cashflow query returned empty for %s; n_cashflow_act field will be missing from records", ts)
+    # P0-1: balancesheet 扩字段 — 补齐 DCF 所需负债/权益/现金字段
     bs_df = tc.query("balancesheet", ts_code=ts,
-                     fields="ts_code,end_date,accounts_rece,inventories",
+                     fields=(
+                         "ts_code,end_date,accounts_rece,inventories,"
+                         "total_liab,total_hldr_eqy_inc_min_int,"
+                         "money_cap,total_cur_assets,total_cur_liab,"
+                         "total_assets"
+                     ),
                      start_date=lookback, end_date=end)
     if bs_df is not None and not bs_df.empty:
         records = _merge_balancesheet_into_financials(records, bs_df.to_dict("records"))
@@ -1000,7 +1077,13 @@ def collect_financials(symbol: str) -> dict:
     })
 
     dim = DimensionResult("financials", results)
-    return dim.to_legacy_dict()
+    legacy = dim.to_legacy_dict()
+    try:
+        from .valuation import attach_dcf_preprocess
+        attach_dcf_preprocess(legacy)
+    except Exception as exc:
+        logger.warning("dcf_preprocess failed for %s: %s", symbol, exc)
+    return legacy
 
 
 def collect_shareholders(symbol: str) -> dict:
@@ -1626,6 +1709,548 @@ def collect_industry(symbol: str) -> dict:
     return dim_dict
 
 
+# ---- 股东增减持采集（P0-2 holder_changes） ----
+
+_HOLDER_SOURCE_RANK: dict[str, int] = {
+    "tushare.stk_holdertrade": 0,
+    "akshare.stock_hold_management_detail_cninfo": 1,
+    "akshare.stock_shareholder_change_ths": 2,
+}
+
+
+def _first_dict_value(row: dict, *keys: str):
+    """取 dict 中第一个非 None 值（保留 0，避免 `or` 误判）。"""
+    for k in keys:
+        if k in row and row[k] is not None:
+            return row[k]
+    return None
+
+
+def _infer_holder_direction(
+    row: dict,
+    change_vol_raw,
+    parsed_vol: float | None = None,
+) -> str:
+    """推断增减持方向：变动类型列 > 文本关键词 > 数量符号。"""
+    for key in ("变动类型", "方向", "变动方向"):
+        typ = str(row.get(key) or "")
+        if "增持" in typ:
+            return "增持"
+        if "减持" in typ:
+            return "减持"
+    raw_s = str(change_vol_raw or "")
+    if "增持" in raw_s:
+        return "增持"
+    if "减持" in raw_s:
+        return "减持"
+    vol = parsed_vol if parsed_vol is not None else _parse_holder_change_vol(change_vol_raw)
+    if vol is not None:
+        if vol > 0:
+            return "增持"
+        if vol < 0:
+            return "减持"
+    return "未知"
+
+
+def _source_has_data(data) -> bool:
+    """源结果是否含有效数据（空列表不算）。"""
+    if data is None:
+        return False
+    if isinstance(data, list):
+        return len(data) > 0
+    return bool(data)
+
+
+def _parse_holder_change_vol(raw) -> float | None:
+    """解析 '增持58.11万' / 5901992.0 → 统一为股数（float）。"""
+    import re
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        f = float(raw)
+        if f != f:  # NaN
+            return None
+        return f
+    s = str(raw).strip().replace(",", "")
+    m = re.search(r"([\d.]+)\s*(万|亿)?", s)
+    if not m:
+        return None
+    val = float(m.group(1))
+    unit = m.group(2) or ""
+    if unit == "万":
+        val *= 10000
+    elif unit == "亿":
+        val *= 1e8
+    return val
+
+
+def _holder_vol_key(raw) -> str:
+    """变动数量归一化 key（万股精度，供跨源匹配）。"""
+    v = _parse_holder_change_vol(raw)
+    if v is None:
+        return str(raw or "")
+    return f"{round(v / 10000, 2)}"
+
+
+def _normalize_holder_name(name: str) -> str:
+    """股东名称归一化（仅用于 transaction key，不修改展示字段）。"""
+    s = str(name or "").strip()
+    for suffix in ("股份有限公司", "有限公司"):
+        if s.endswith(suffix):
+            s = s[: -len(suffix)].strip()
+            break
+    return s
+
+
+def _holder_transaction_key(r: dict) -> tuple:
+    return (
+        _normalize_holder_name(str(r.get("holder_name", ""))),
+        str(r.get("ann_date", ""))[:10],
+        str(r.get("direction", "")),
+        _holder_vol_key(r.get("change_vol")),
+    )
+
+
+def _norm_date(raw: str) -> str:
+    """日期归一化：尝试 YYYYMMDD / YYYY-MM-DD / YYYY.MM.DD → YYYYMMDD。"""
+    import re
+    raw = str(raw).strip()
+    # 已为 YYYYMMDD
+    if re.match(r'^\d{8}$', raw):
+        return raw
+    # YYYY-MM-DD 或 YYYY.MM.DD
+    m = re.search(r'(\d{4})[-./](\d{1,2})[-./](\d{1,2})', raw)
+    if m:
+        return f"{m.group(1)}{int(m.group(2)):02d}{int(m.group(3)):02d}"
+    # 区间格式 "2015.07.23-2015.07.23" → search 已取首段
+    return raw[:8] if len(raw) >= 8 and raw[:8].isdigit() else raw
+
+
+def _q_tushare_holdertrade(symbol: str) -> list[dict] | None:
+    """Tushare stk_holdertrade — 股东增减持（主源）。"""
+    from . import env as _env
+    config = _env.get_config()
+    if not _env.is_tushare_available(config):
+        raise RuntimeError("TUSHARE_TOKEN not configured")
+    tc = _tushare_client(config)
+    ts = _ts_code(symbol)
+    df = tc.query(
+        "stk_holdertrade", ts_code=ts,
+        start_date=_days_ago(730), end_date=_today(),
+        fields="ts_code,ann_date,holder_name,holder_type,in_de,"
+               "change_vol,change_ratio,avg_price,after_share,after_ratio",
+    )
+    if df is None or df.empty:
+        return None
+    records = df.to_dict("records")
+    for rec in records:
+        rec["direction"] = "增持" if rec.get("in_de") == "IN" else "减持"
+        rec["source"] = "Tushare stk_holdertrade"
+    return records
+
+
+def _run_with_timeout(fn: Callable[[], Any], timeout_sec: float, label: str) -> Any:
+    """在独立线程中执行阻塞调用，超时则返回 None（用于 cninfo 全市场扫描）。"""
+    from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(fn)
+        try:
+            return future.result(timeout=timeout_sec)
+        except FuturesTimeoutError:
+            logger.warning("%s timed out after %.0fs, skipping", label, timeout_sec)
+            return None
+        except Exception as exc:
+            logger.warning("%s failed: %s", label, exc)
+            return None
+
+
+def _q_akshare_management_hold(symbol: str) -> list[dict] | None:
+    """akshare stock_hold_management_detail_cninfo — 高管增减持（副源）。
+
+    该接口按「增持/减持」分类返回全市场数据（~9500+17300 行），
+    需按 symbol 过滤。⚠️ 内部使用 JS 引擎，不可在并行采集线程池中执行。
+    单次请求超时见 env.CNINFO_HOLDER_TIMEOUT_SEC，超时则跳过该方向。
+    """
+    if not env.is_akshare_available():
+        return None
+    import akshare as ak
+
+    sym = symbol.strip().zfill(6)
+    records: list[dict] = []
+    timeout_sec = float(env.CNINFO_HOLDER_TIMEOUT_SEC)
+
+    for direction in ("增持", "减持"):
+        df = _run_with_timeout(
+            lambda d=direction: ak.stock_hold_management_detail_cninfo(symbol=d),
+            timeout_sec,
+            f"akshare cninfo({direction})",
+        )
+        if df is None or getattr(df, "empty", True):
+            continue
+        # 过滤当前标的
+        code_col = "证券代码" if "证券代码" in df.columns else (
+            "股票代码" if "股票代码" in df.columns else None)
+        if code_col is None:
+            logger.warning(
+                "akshare cninfo(%s): missing symbol column (%s), skip",
+                direction, list(df.columns),
+            )
+            continue
+        df = df[df[code_col].astype(str).str.contains(sym, na=False)]
+        if df.empty:
+            continue
+        for row in df.to_dict("records"):
+            records.append({
+                "ann_date": _norm_date(
+                    row.get("公告日期") or row.get("变动日期") or ""),
+                "holder_name": row.get("董监高姓名") or row.get("高管姓名") or row.get("变动人") or "",
+                "position": row.get("董监高职务") or row.get("职务") or "",
+                "direction": direction,
+                "change_vol": _first_dict_value(row, "变动数量", "变动股数"),
+                "avg_price": _first_dict_value(row, "成交均价", "交易均价"),
+                "reason": row.get("持股变动原因") or row.get("变动原因") or "",
+                "source": "akshare cninfo",
+            })
+    return records or None
+
+
+def _q_akshare_shareholder_change_ths(symbol: str) -> list[dict] | None:
+    """akshare stock_shareholder_change_ths — 同花顺股东变动（降级备选）。"""
+    if not env.is_akshare_available():
+        return None
+    import akshare as ak
+    df = ak.stock_shareholder_change_ths(symbol=symbol.strip().zfill(6))
+    if df is None or df.empty:
+        return None
+    records = []
+    for row in df.to_dict("records"):
+        change_vol_raw = row.get("变动数量")
+        parsed_vol = _parse_holder_change_vol(change_vol_raw)
+        direction = _infer_holder_direction(row, change_vol_raw, parsed_vol)
+        records.append({
+            "ann_date": _norm_date(str(row.get("公告日期") or row.get("变动期间") or "")),
+            "holder_name": row.get("变动股东") or "",
+            "change_vol": parsed_vol if parsed_vol is not None else change_vol_raw,
+            "change_vol_raw": change_vol_raw,
+            "avg_price": row.get("交易均价"),
+            "remain_vol": row.get("剩余股份总数"),
+            "direction": direction,
+            "source": "akshare ths",
+        })
+    return records or None
+
+
+def _merge_holder_records(results: list) -> list[dict]:
+    """合并多源增减持记录，按 transaction_key 分组并标注 cross_check。
+
+    同源同日多笔交易（不同变动数量）全部保留；仅跨源命中同一笔时折叠为 1 条。
+    去重优先级：Tushare > akshare cninfo > akshare ths。
+    """
+    pending: list[dict] = []
+    for sr in results:
+        if not sr.success or sr.data is None:
+            continue
+        records = sr.data if isinstance(sr.data, list) else [sr.data]
+        for r in records:
+            if not isinstance(r, dict):
+                continue
+            rec = dict(r)
+            rec["_source_api_key"] = sr.source
+            rec["_source_rank"] = _HOLDER_SOURCE_RANK.get(sr.source, 99)
+            pending.append(rec)
+
+    if not pending:
+        return []
+
+    groups: dict[tuple, list[dict]] = {}
+    for r in pending:
+        groups.setdefault(_holder_transaction_key(r), []).append(r)
+
+    merged: list[dict] = []
+    for group in groups.values():
+        sources = {r["_source_api_key"] for r in group}
+        if len(sources) > 1:
+            group.sort(key=lambda r: r.get("_source_rank", 99))
+            best = group[0]
+            best["cross_check"] = len(sources)
+            best.pop("_source_api_key", None)
+            best.pop("_source_rank", None)
+            merged.append(best)
+        else:
+            for r in group:
+                r["cross_check"] = 1
+                r.pop("_source_api_key", None)
+                r.pop("_source_rank", None)
+                merged.append(r)
+
+    merged.sort(key=lambda r: str(r.get("ann_date", "")), reverse=True)
+    return merged
+
+
+def _needs_cninfo_holder_fallback(results: list) -> bool:
+    """并行源（Tushare + ths）均有数据时跳过慢速 cninfo；否则顺序补采。"""
+    has_tushare = any(
+        r.source == "tushare.stk_holdertrade" and _source_has_data(r.data)
+        for r in results
+    )
+    has_ths = any(
+        r.source == "akshare.stock_shareholder_change_ths" and _source_has_data(r.data)
+        for r in results
+    )
+    return not (has_tushare and has_ths)
+
+
+def collect_holder_changes(symbol: str) -> dict:
+    """股东增减持动向 — 三源并行 + 交叉验证（与 collect_financials 同构）。
+
+    cninfo 源因内部使用 JS 引擎（mini_racer），不在线程池中执行。
+    当 Tushare 与 ths 并行源均有数据时跳过 cninfo；否则顺序补采高管维度数据。
+    """
+    # 线程安全的源（Tushare + ths）
+    tasks: list[tuple[str, Callable]] = []
+    if env.is_tushare_available(env.get_config()):
+        tasks.append(("tushare.stk_holdertrade", lambda: _q_tushare_holdertrade(symbol)))
+    if env.is_akshare_available():
+        tasks.append(("akshare.stock_shareholder_change_ths",
+                      lambda: _q_akshare_shareholder_change_ths(symbol)))
+
+    results = _run_sources_parallel(tasks, "holder_changes")
+
+    # cninfo 源（不可在线程中运行 — 内部使用 JS 引擎，且全市场数据极慢）
+    if env.is_akshare_available() and _needs_cninfo_holder_fallback(results):
+        results.append(_run_one_source(
+            "akshare.stock_hold_management_detail_cninfo",
+            lambda: _q_akshare_management_hold(symbol),
+            "holder_changes",
+        ))
+
+    result_map = {r.source: r for r in results}
+    _annotate_query_params(result_map, {
+        "tushare.stk_holdertrade": _qp_tushare("stk_holdertrade", symbol,
+                                               start_date=_days_ago(730), end_date=_today()),
+        "akshare.stock_hold_management_detail_cninfo": _qp_akshare(
+            "stock_hold_management_detail_cninfo", symbol),
+        "akshare.stock_shareholder_change_ths": _qp_akshare(
+            "stock_shareholder_change_ths", symbol),
+    })
+
+    dim = DimensionResult("holder_changes", results)
+    legacy = dim.to_legacy_dict()
+    # 合并多源记录做去重 + 交叉验证标注
+    merged = _merge_holder_records(results)
+    legacy["data"] = merged if merged else legacy.get("data")
+    return legacy
+
+
+# ---- 行业定价采集（P1-2 + P1-3 industry_pricing） ----
+
+def _calc_futures_trend(daily_df, days: int = 30) -> str:
+    """从 futures_spot_price_daily 的 DataFrame 计算近 N 日趋势（v0.1.8 扩展用）。"""
+    if daily_df is None or daily_df.empty:
+        return "数据不足"
+    tail = daily_df.tail(days)
+    prices = tail.get("spot_price") if "spot_price" in tail.columns else tail.get("sp")
+    if prices is None or len(prices) < 5:
+        return "数据不足"
+    try:
+        first = float(prices.iloc[0])
+        last = float(prices.iloc[-1])
+        pct = (last - first) / abs(first) * 100 if first != 0 else 0
+        arrow = "↗" if pct > 0 else "↘" if pct < 0 else "→"
+        return f"{arrow} {pct:+.1f}%"
+    except (TypeError, ValueError, IndexError):
+        return "数据不足"
+
+
+def _calc_futures_trend_from_spot(spot_old, spot_new, code: str, code_col: str) -> str:
+    """对比两日期货现货价，计算近 30 日趋势（2 次 API，不按品种循环）。"""
+    if spot_old is None or spot_old.empty or spot_new is None or spot_new.empty:
+        return "数据不足"
+    row_old = spot_old[spot_old[code_col] == code]
+    row_new = spot_new[spot_new[code_col] == code]
+    if row_old.empty or row_new.empty:
+        return "数据不足"
+    try:
+        old_p = safe_float(row_old.iloc[-1].get("spot_price") or row_old.iloc[-1].get("sp"))
+        new_p = safe_float(row_new.iloc[-1].get("spot_price") or row_new.iloc[-1].get("sp"))
+        if old_p is None or new_p is None or old_p == 0:
+            return "数据不足"
+        pct = (new_p - old_p) / abs(old_p) * 100
+        arrow = "↗" if pct > 0 else "↘" if pct < 0 else "→"
+        return f"{arrow} {pct:+.1f}%"
+    except (TypeError, ValueError, IndexError):
+        return "数据不足"
+
+
+def _q_akshare_futures_spot(symbol: str, industry: str) -> dict | None:
+    """期货现货价格 + 近月合约价格 + 基差率。"""
+    from .chain import get_futures_for_industry
+
+    futures_list = get_futures_for_industry(industry)
+    if not futures_list:
+        return None
+
+    if not env.is_akshare_available():
+        return None
+    import akshare as ak
+
+    codes = [code for _, code in futures_list]
+    results = {}
+    # 尝试昨天 → 前天（期货数据通常 T+1 更新，跳过今天）
+    spot = None
+    for day_offset in (1, 2, 3):
+        try:
+            spot = ak.futures_spot_price(date=_days_ago(day_offset), vars_list=codes)
+            if spot is not None and not spot.empty:
+                break
+        except Exception:
+            continue
+
+    if spot is None or spot.empty:
+        return None
+
+    spot_old = None
+    try:
+        spot_old = ak.futures_spot_price(date=_days_ago(30), vars_list=codes)
+    except Exception:
+        pass
+
+    code_col = "symbol" if "symbol" in spot.columns else "var"
+    for name, code in futures_list:
+        row = spot[spot[code_col] == code]
+        if row.empty:
+            results[name] = {"code": code, "error": "无数据"}
+            continue
+        r = row.iloc[-1]
+        trend = _calc_futures_trend_from_spot(spot_old, spot, code, code_col)
+        results[name] = {
+            "code": code,
+            "spot_price": r.get("spot_price") or r.get("sp"),
+            "near_month_price": r.get("near_contract_price") or r.get("near_price"),
+            "dom_price": r.get("dominant_contract_price") or r.get("dom_price"),
+            "near_basis_rate": r.get("near_basis_rate"),
+            "dom_basis_rate": r.get("dom_basis_rate"),
+            "trend_30d": trend,
+        }
+
+    return results or None
+
+
+def _q_akshare_company_news_price(symbol: str) -> dict | None:
+    """公司新闻涨价信号检测。正则匹配: 涨价|提价|上调|调价|价格上涨。"""
+    import re
+    from datetime import datetime, timedelta
+
+    if not env.is_akshare_available():
+        return None
+    import akshare as ak
+    with akshare_direct_session():
+        df = ak.stock_news_em(symbol=symbol.strip().zfill(6))
+    if df is None or df.empty:
+        return None
+
+    pattern = re.compile(r"涨价|提价|上调|调价|价格上涨")
+    cutoff = datetime.now() - timedelta(days=30)
+    matches = []
+    for row in df.to_dict("records"):
+        title = str(row.get("新闻标题", ""))
+        content = str(row.get("新闻内容", ""))
+        if not (pattern.search(title) or pattern.search(content)):
+            continue
+        date_raw = str(row.get("发布时间", ""))
+        if not _news_date_within(date_raw, cutoff):
+            continue
+        matches.append({
+            "date": date_raw,
+            "title": title,
+            "content_snippet": content[:200],
+        })
+
+    signal = "确认" if len(matches) >= 2 else ("单条" if len(matches) == 1 else "无")
+    return {
+        "matches": matches,
+        "signal": signal,
+        "signal_detail": f"近 30 日 {len(matches)} 条涨价相关新闻",
+    }
+
+
+def _parse_news_datetime(date_raw: str):
+    """解析 akshare stock_news_em 发布时间。"""
+    from datetime import datetime
+
+    raw = str(date_raw).strip()
+    if not raw:
+        return None
+    for fmt, maxlen in (
+        ("%Y-%m-%d %H:%M:%S", 19),
+        ("%Y-%m-%d %H:%M", 16),
+        ("%Y-%m-%d", 10),
+        ("%Y/%m/%d", 10),
+    ):
+        try:
+            return datetime.strptime(raw[:maxlen], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _news_date_within(date_raw: str, cutoff) -> bool:
+    """判断新闻是否在 cutoff 之后（近 30 日窗口）。"""
+    dt = _parse_news_datetime(date_raw)
+    return dt is not None and dt >= cutoff
+
+
+def _resolve_industry_for_pricing(
+    symbol: str,
+    dim_results: dict[str, dict] | None = None,
+) -> str:
+    """解析行业名（优先已采集 basic_info，否则补采）。"""
+    if dim_results:
+        basic = dim_results.get("basic_info")
+        if basic:
+            industry = extract_industry_from_basic_info(basic.get("data"))
+            if industry:
+                return industry
+    try:
+        basic = collect_basic_info(symbol)
+        return extract_industry_from_basic_info(basic.get("data")) or ""
+    except Exception as exc:
+        logger.warning(
+            "industry_pricing: industry lookup failed for %s: %s", symbol, exc,
+        )
+        return ""
+
+
+def collect_industry_pricing_dim(symbol: str) -> dict:
+    """COLLECTORS 入口：采集前解析行业（期货映射依赖 industry）。"""
+    return collect_industry_pricing(
+        symbol, _resolve_industry_for_pricing(symbol),
+    )
+
+
+def collect_industry_pricing(symbol: str, industry: str = "") -> dict:
+    """行业产品定价追踪（与 collect_financials 同构）。"""
+    from .chain import get_futures_for_industry
+
+    tasks: list[tuple[str, Callable]] = [
+        ("akshare.futures_spot_price",
+         lambda: _q_akshare_futures_spot(symbol, industry)),
+    ]
+    if env.is_akshare_available():
+        tasks.append(("akshare.stock_news_em",
+                      lambda: _q_akshare_company_news_price(symbol)))
+
+    results = _run_sources_parallel(tasks, "industry_pricing")
+    dim = DimensionResult("industry_pricing", results)
+    legacy = dim.to_legacy_dict()
+    legacy.setdefault("data", {})
+    if isinstance(legacy["data"], dict):
+        legacy["data"]["industry"] = industry
+        legacy["data"]["has_futures"] = bool(get_futures_for_industry(industry))
+    return legacy
+
+
 # ---- 全维度采集 ----
 
 COLLECTORS = {
@@ -1638,10 +2263,12 @@ COLLECTORS = {
     "valuation": ("估值分析", collect_valuation),
     "research": ("机构研报", collect_research),
     "industry": ("行业数据", collect_industry),  # R-11: NEW
+    "holder_changes": ("股东增减持", collect_holder_changes),  # P0-2
+    "industry_pricing": ("行业定价", collect_industry_pricing_dim),  # P1-2
 }
 
 _DEFAULT_DIMS = ["basic_info", "financials", "quote", "shareholders",
-                 "northbound", "valuation", "kline"]
+                 "northbound", "valuation", "kline", "holder_changes"]
 
 
 def collect_all(symbol: str, dims: list[str] | None = None,
@@ -1677,6 +2304,8 @@ def collect_all(symbol: str, dims: list[str] | None = None,
             if dim not in COLLECTORS:
                 logger.warning("忽略未知维度 '%s'（有效维度: %s）", dim, list(COLLECTORS.keys()))
                 continue
+            if dim == "industry_pricing":
+                continue
             if dim == "kline" and kline_kwargs:
                 _, fn = COLLECTORS[dim]
                 future_map[executor.submit(fn, symbol, **kline_kwargs)] = dim
@@ -1699,6 +2328,24 @@ def collect_all(symbol: str, dims: list[str] | None = None,
                               "all_sources": [], "multi_source": False,
                               "source_count": 0, "error": str(exc)},
                 }
+
+    if "industry_pricing" in dims:
+        try:
+            industry = _resolve_industry_for_pricing(symbol, dim_results)
+            dim_results["industry_pricing"] = collect_industry_pricing(symbol, industry)
+        except Exception as exc:
+            dim_results["industry_pricing"] = {
+                "dimension": "industry_pricing",
+                "display": COLLECTORS["industry_pricing"][0],
+                "data": None,
+                "status": "missing",
+                "error": f"维度采集失败: {exc}",
+                "_meta": {
+                    "source": "none", "success": False,
+                    "all_sources": [], "multi_source": False,
+                    "source_count": 0, "error": str(exc),
+                },
+            }
 
     # 按输入顺序排列
     dimensions = [dim_results.get(d) for d in dims if d in COLLECTORS]
@@ -2764,6 +3411,79 @@ def attach_pe_band(collection: dict, *, years: int = 5) -> dict[str, Any] | None
     return band
 
 
+# P3-3: 价格异常检测原型（预留 v0.1.9 news 全栈使用）
+
+
+def _extract_kline_from_collection(collection: dict) -> list:
+    """从 collect_all 结果中提取 kline 维度数据列表。"""
+    for dim in collection.get("dimensions", []):
+        if dim.get("dimension") == "kline":
+            data = dim.get("data")
+            if isinstance(data, list):
+                return data
+    return []
+
+
+def _bar_pct_chg(bar: dict, prev_bar: dict | None) -> float | None:
+    """从 pct_chg 字段或相邻 close 计算涨跌幅（%）。"""
+    raw = bar.get("pct_chg")
+    if raw is not None:
+        pct = safe_float(raw)
+        if pct is not None:
+            return pct
+    if prev_bar is None:
+        return None
+    close = safe_float(bar.get("close"))
+    prev_close = safe_float(prev_bar.get("close"))
+    if close is not None and prev_close is not None and prev_close != 0:
+        return (close - prev_close) / prev_close * 100
+    return None
+
+
+def _detect_price_shock(symbol: str, kline_data: list) -> dict:
+    """价格异常检测原型。
+
+    当前仅检测极端涨跌停，不做新闻关联。
+    v0.1.9 将扩展为：价格异常 + 新闻关联 + 事件归因。
+
+    Returns:
+        {"has_shock": bool, "shock_dates": [...], "shock_type": str|None}
+    """
+    if not kline_data:
+        return {"has_shock": False, "shock_dates": []}
+
+    bars = kline_data[-61:] if len(kline_data) > 1 else kline_data
+    shocks = []
+    for i in range(1, len(bars)):
+        bar = bars[i]
+        pct = _bar_pct_chg(bar, bars[i - 1])
+        if pct is None:
+            continue
+        if abs(pct) >= 9.5:  # A股涨跌停阈值
+            shocks.append({
+                "date": bar.get("trade_date"),
+                "pct_chg": round(pct, 2),
+                "type": "limit_up" if pct > 0 else "limit_down",
+            })
+
+    def _classify(s: list) -> str | None:
+        if not s:
+            return None
+        up = sum(1 for x in s if x["type"] == "limit_up")
+        dn = len(s) - up
+        if up >= 2 and dn == 0:
+            return "连续涨停"
+        elif dn >= 2 and up == 0:
+            return "连续跌停"
+        return "混合异常"
+
+    return {
+        "has_shock": len(shocks) > 0,
+        "shock_dates": shocks,
+        "shock_type": _classify(shocks),
+    }
+
+
 def attach_phase2_extras(collection: dict, symbol: str) -> None:
     """挂载 Phase 2 扩展数据（同行、PE Band）。"""
     errors: list[str] = []
@@ -2787,6 +3507,30 @@ def attach_phase2_extras(collection: dict, symbol: str) -> None:
         except Exception as exc:
             errors.append(f"pe_band: {exc}")
             collection["pe_band"] = None
+
+    # P1-2: industry_pricing — 依赖 basic_info 已采集的行业信息
+    if collection.get("industry_pricing") is None:
+        try:
+            industry = extract_industry_from_collection(collection) or ""
+            collection["industry_pricing"] = collect_industry_pricing(symbol, industry)
+        except Exception as exc:
+            errors.append(f"industry_pricing: {exc}")
+            collection["industry_pricing"] = {
+                "dimension": "industry_pricing", "data": None,
+                "status": "missing", "error": f"行业定价采集异常: {exc}",
+            }
+
+    # P3-3: 价格异常检测（非阻塞）
+    if collection.get("price_shock") is None:
+        try:
+            kline_bars = _extract_kline_from_collection(collection)
+            collection["price_shock"] = _detect_price_shock(symbol, kline_bars)
+        except Exception as exc:
+            errors.append(f"price_shock: {exc}")
+            collection["price_shock"] = {
+                "has_shock": False, "shock_dates": [], "error": str(exc),
+            }
+
     if errors:
         collection.setdefault("phase2_extras_errors", []).extend(errors)
         logger.warning("attach_phase2_extras partial failure for %s: %s", symbol, errors)

--- a/skills/invest-A/scripts/lib/env.py
+++ b/skills/invest-A/scripts/lib/env.py
@@ -165,6 +165,25 @@ def diagnose(config: dict[str, Any] | None = None) -> dict[str, Any]:
     }
 
 
+# P3-2: WebSearch 白名单（涨价信号触发时使用）
+PRICE_NEWS_WHITELIST = [
+    "stcn.com",              # 证券时报
+    "cnstock.com",           # 上海证券报/中国证券网
+    "cs.com.cn",             # 中国证券报
+    "21jingji.com",          # 21世纪经济报道
+    "eeo.com.cn",            # 经济观察报
+    "finance.sina.com.cn",   # 新浪财经
+    "10jqka.com.cn",         # 同花顺
+    "cls.cn",                # 财联社
+]
+# ⚠️ 东方财富 (eastmoney.com) 因代理问题暂不列入
+
+# cninfo 高管增减持全市场接口超时（秒）；超时则跳过该方向
+CNINFO_HOLDER_TIMEOUT_SEC = max(
+    5, int(os.environ.get("INVEST_CNINFO_HOLDER_TIMEOUT", "45"))
+)
+
+
 def ensure_env_loaded() -> None:
     """将 .env 变量注入 os.environ（向后兼容）。"""
     for key, value in load_env_file(PROJECT_ENV_FILE).items():

--- a/skills/invest-A/scripts/lib/render.py
+++ b/skills/invest-A/scripts/lib/render.py
@@ -82,7 +82,44 @@ def _render_engine_extras(collection: dict[str, Any]) -> list[str]:
         cred_s = ", ".join(f"{k}={v:.0f}" for k, v in top)
         lines.append(f"**[证据可信度]** {cred_s}")
 
+    lines.extend(_render_enhancement_hints(collection))
+
     return lines
+
+
+def _render_enhancement_hints(collection: dict[str, Any]) -> list[str]:
+    """渲染 ReportEnhancer 触发的可操作建议。"""
+    enhancements = collection.get("_enhancements") or {}
+    if not enhancements:
+        return []
+
+    lines: list[str] = ["**[报告增强触发]**"]
+
+    price_ws = enhancements.get("price_shock_websearch")
+    if isinstance(price_ws, dict) and price_ws.get("triggered"):
+        from .env import PRICE_NEWS_WHITELIST
+        sites = " OR ".join(f"site:{d}" for d in PRICE_NEWS_WHITELIST[:4])
+        lines.append(f"- 涨价信号确认 → 建议 WebSearch 深搜（{sites} ...）")
+
+    val_alert = enhancements.get("valuation_high_alert")
+    if isinstance(val_alert, dict) and val_alert.get("triggered"):
+        lines.append("- PE 历史位置≥80% → 建议触发源 B 类增强（估值区间驱动）")
+
+    shock = enhancements.get("price_shock_detect")
+    if isinstance(shock, dict) and shock.get("has_shock"):
+        dates = shock.get("shock_dates") or []
+        shock_type = shock.get("shock_type") or "异常波动"
+        date_parts = []
+        for s in dates[:5]:
+            if s.get("date") is None:
+                continue
+            pct = _safe_num(s.get("pct_chg"))
+            pct_s = f"{pct:+.1f}%" if pct is not None else "—"
+            date_parts.append(f"{s.get('date')}({pct_s})")
+        date_s = ", ".join(date_parts)
+        lines.append(f"- 近 60 日价格异常（{shock_type}）: {date_s or '—'}")
+
+    return lines if len(lines) > 1 else []
 
 _EASTMONEY_BLOCKED_SHORT = "东方财富(East Money)主动拒绝连接"
 _RAW_CONNECTION_REFUSED_SHORT = "服务器拒绝连接"
@@ -1643,6 +1680,12 @@ def _section_snapshot(
     ))
     lines.append("")
     lines.append("🔍 **待独立验证:** 快照数字应与财报 PDF / 交易所行情交叉核对。")
+
+    futures_block = _render_pricing_futures_section(collection.get("industry_pricing", {}))
+    if futures_block:
+        lines.append("")
+        lines.append(futures_block)
+
     return "\n".join(lines)
 
 
@@ -1830,6 +1873,12 @@ def _section_dynamic_drivers(
     lines.append(f"→ **主导因子（声明）:** {dominant}")
     lines.append("")
     lines.append("🔍 **待独立验证:** 候选解释仅为假说列表，非因果归因。")
+
+    news_block = _render_pricing_news_section(collection.get("industry_pricing", {}))
+    if news_block:
+        lines.append("")
+        lines.append(news_block)
+
     return "\n".join(lines)
 
 
@@ -2162,6 +2211,198 @@ def _competitive_position_label(pct: float | None) -> str | None:
     if pct >= 40:
         return "挑战者"
     return "追赶者"
+
+
+def _section_holder_changes(data: dict) -> str:
+    """股东增减持动向（P0-2 holder_changes 渲染）。"""
+    if not data or not isinstance(data, dict):
+        return ""
+    records = data.get("data") or []
+    if not records or not isinstance(records, list) or len(records) == 0:
+        return ""
+
+    lines = ["## 3d. 股东增减持动向", ""]
+
+    # 近期重要变动表格
+    lines.append("### 近期重要变动（近 2 年）")
+    lines.append("")
+    lines.append("| 公告日期 | 股东名称 | 方向 | 变动数量(万) | 变动比例(%) | 均价 | 来源 | 交叉验证 |")
+    lines.append("|----------|---------|------|-------------|------------|------|------|---------|")
+    for r in records[:20]:
+        date = str(r.get("ann_date", ""))
+        if len(date) == 8:
+            date = f"{date[:4]}-{date[4:6]}-{date[6:8]}"
+        name = str(r.get("holder_name", ""))[:16]
+        direction = str(r.get("direction", ""))
+        vol = r.get("change_vol")
+        vol_str = ""
+        if vol is not None:
+            v = _safe_num(vol)
+            if v is not None:
+                if abs(v) >= 10000:
+                    vol_str = f"{v / 10000:.0f}万"
+                else:
+                    vol_str = f"{v:.0f}"
+            else:
+                vol_str = str(r.get("change_vol_raw") or vol)[:12]
+        ratio = _safe_num(r.get("change_ratio"))
+        ratio_str = f"{ratio:.2f}" if ratio is not None else ""
+        price = _safe_num(r.get("avg_price"))
+        price_str = f"{price:.2f}" if price is not None else "—"
+        source = str(r.get("source", ""))
+        cc = r.get("cross_check", 1)
+        cc_str = f"{cc}源一致" if cc >= 2 else ""
+        lines.append(
+            f"| {date} | {name} | {direction} | {vol_str} | {ratio_str} | "
+            f"{price_str} | {source} | {cc_str} |"
+        )
+    lines.append("")
+
+    # 信号分析
+    lines.append("### 信号分析")
+    lines.append("")
+
+    # 净增/减持方向
+    buy_count = sum(1 for r in records if "增" in str(r.get("direction", "")))
+    sell_count = sum(1 for r in records if "减" in str(r.get("direction", "")))
+    lines.append(f"- **净增/减持方向**: 近 2 年 增持 {buy_count} 笔，减持 {sell_count} 笔")
+
+    # 关键主体（按出现次数排序）
+    from collections import Counter
+    name_counter = Counter(
+        str(r.get("holder_name", ""))[:12] for r in records
+    )
+    top_names = name_counter.most_common(3)
+    if top_names:
+        lines.append(f"- **关键主体**: {', '.join(f'{n}({c}次)' for n, c in top_names)}")
+
+    # 内部人一致性
+    if buy_count >= 3 and sell_count == 0:
+        lines.append("- **内部人一致性**: 多主体同向增持 → 信号增强")
+    elif sell_count >= 3 and buy_count == 0:
+        lines.append("- **内部人一致性**: 多主体同向减持 → 信号增强（负面）")
+    else:
+        lines.append("- **内部人一致性**: 增减持方向分歧，信号混杂")
+
+    return "\n".join(lines)
+
+
+def _industry_pricing_parts(data: dict) -> tuple[dict, list]:
+    """解析 industry_pricing legacy dict → (inner, all_sources)。"""
+    if not data or not isinstance(data, dict):
+        return {}, []
+    inner = data.get("data") or {}
+    if not isinstance(inner, dict):
+        return {}, []
+    all_srcs = data.get("_meta", {}).get("all_sources", [])
+    return inner, all_srcs
+
+
+def _render_pricing_futures_section(data: dict) -> str:
+    """模块 1：原材料成本速览（期货现货）。"""
+    inner, all_srcs = _industry_pricing_parts(data)
+    if not inner:
+        return ""
+
+    has_futures = inner.get("has_futures", False)
+    lines: list[str] = []
+
+    if has_futures:
+        lines.append("### 原材料成本速览")
+        lines.append("")
+        futures_data: dict = {}
+        for src in all_srcs:
+            if src.get("source") == "akshare.futures_spot_price" and src.get("data"):
+                futures_data = src.get("data") or {}
+                break
+        if not futures_data:
+            for k, v in inner.items():
+                if isinstance(v, dict) and "code" in v:
+                    futures_data[k] = v
+
+        if futures_data:
+            lines.append("| 品种 | 代码 | 现货价 | 主力合约 | 主力基差率 | 近30日趋势 |")
+            lines.append("|------|------|--------|---------|-----------|-----------|")
+            for name, info in futures_data.items():
+                if not isinstance(info, dict):
+                    continue
+                code = info.get("code", "")
+                spot_n = _safe_num(info.get("spot_price"))
+                spot_s = f"{spot_n:,.0f}" if spot_n is not None else "—"
+                dom_n = _safe_num(info.get("dom_price"))
+                dom_s = f"{dom_n:,.0f}" if dom_n is not None else "—"
+                basis_n = _safe_num(info.get("dom_basis_rate"))
+                basis_s = f"{basis_n:.2f}%" if basis_n is not None else "—"
+                trend = info.get("trend_30d", "—")
+                lines.append(f"| {name} | {code} | {spot_s} | {dom_s} | {basis_s} | {trend} |")
+            lines.append("")
+
+    industry = inner.get("industry", "")
+    note = f"> 行业: {industry} | 数据来源: akshare 期货现货" if industry else ""
+    if not has_futures:
+        note = (note + " | ⚠️ 该行业无期货映射，仅靠新闻源") if note else \
+            "> ⚠️ 该行业无期货映射，仅靠新闻源"
+    if note:
+        lines.append(note)
+
+    return "\n".join(lines) if lines else ""
+
+
+def _render_pricing_news_section(data: dict) -> str:
+    """模块 2：涨价信号（公司新闻）。"""
+    inner, all_srcs = _industry_pricing_parts(data)
+    if not inner:
+        return ""
+
+    news_data: dict = {}
+    for src in all_srcs:
+        if src.get("source") == "akshare.stock_news_em" and src.get("data"):
+            news_data = src.get("data") or {}
+            break
+
+    if not news_data:
+        return ""
+
+    signal = news_data.get("signal", "无")
+    detail = news_data.get("signal_detail", "")
+    lines = [
+        "### 涨价信号",
+        "",
+        f"**状态: {'涨价趋势确认' if signal == '确认' else '单条涨价新闻' if signal == '单条' else '无涨价信号'}**（{detail}）",
+        "",
+    ]
+
+    matches = news_data.get("matches") or []
+    if matches:
+        lines.append("| 日期 | 标题 |")
+        lines.append("|------|------|")
+        for m in matches[:10]:
+            date = str(m.get("date", ""))[:10]
+            title = str(m.get("title", ""))[:50]
+            lines.append(f"| {date} | {title} |")
+        lines.append("")
+        lines.append("> 🔍 待验证: WebSearch 深搜确认涨价幅度和持续性")
+
+    return "\n".join(lines)
+
+
+def _section_industry_pricing(data: dict) -> str:
+    """行业产品定价追踪（兼容旧调用；新报告已拆分至模块 1/2）。"""
+    futures = _render_pricing_futures_section(data)
+    news = _render_pricing_news_section(data)
+    if not futures and not news:
+        return ""
+    parts = []
+    if futures or news:
+        parts.append("## 3e. 行业产品定价追踪")
+        parts.append("")
+    if futures:
+        parts.append(futures)
+    if news:
+        if futures:
+            parts.append("")
+        parts.append(news)
+    return "\n".join(parts)
 
 
 def _v3_trigger_c_active(market_structure: dict) -> bool:
@@ -4641,10 +4882,93 @@ def _section_core_tension(
     return "\n".join(lines)
 
 
+# ═══════════════════════════════════════════════════════════════
+# P3-1: ReportEnhancer 触发器统一
+# ═══════════════════════════════════════════════════════════════
+
+
+class ReportEnhancer:
+    """Report 阶段增强触发器统一管理。
+
+    所有增强逻辑通过 register / apply 机制调用，
+    避免在 render_report_v3() 中散落 if-else。
+    """
+
+    def __init__(self, data: dict):
+        self.data = data
+        self._enhancers: list[tuple[str, callable, callable]] = []
+
+    def register(self, name: str, condition, enhancer_fn):
+        """注册增强器：条件满足时自动调用。"""
+        self._enhancers.append((name, condition, enhancer_fn))
+
+    def apply(self) -> dict:
+        """执行所有满足条件的增强器，返回增强结果。"""
+        results = {}
+        for name, condition, fn in self._enhancers:
+            try:
+                if condition(self.data):
+                    results[name] = fn(self.data)
+            except Exception as e:
+                results[name] = {"error": str(e)}
+        return results
+
+
+def _has_price_signal(data: dict) -> bool:
+    """检查是否触发涨价信号。"""
+    ip = data.get("industry_pricing")
+    if not isinstance(ip, dict):
+        return False
+    for src in ip.get("_meta", {}).get("all_sources", []):
+        if not isinstance(src, dict):
+            continue
+        nd = src.get("data")
+        if isinstance(nd, dict) and nd.get("signal") == "确认":
+            return True
+    return False
+
+
+def _is_valuation_extreme(data: dict, percentile: float = 80) -> bool:
+    """检查估值分位是否超过阈值（从 dimensions 读取，与报告其他模块一致）。"""
+    dims = _index_dims(data)
+    pe_pct, _, _ = _v3_valuation_percentiles(dims, {})
+    return pe_pct is not None and pe_pct >= percentile
+
+
+def setup_default_enhancers(data: dict) -> ReportEnhancer:
+    """配置默认增强器集合。"""
+    enhancer = ReportEnhancer(data)
+
+    enhancer.register(
+        "price_shock_websearch",
+        _has_price_signal,
+        lambda d: {"triggered": True, "reason": "涨价信号确认，建议 WebSearch 深搜"},
+    )
+
+    enhancer.register(
+        "valuation_high_alert",
+        lambda d: _is_valuation_extreme(d, percentile=80),
+        lambda d: {"triggered": True, "reason": "PE 历史位置≥80%，建议 B 类增强"},
+    )
+
+    enhancer.register(
+        "price_shock_detect",
+        lambda d: bool((d.get("price_shock") or {}).get("has_shock")),
+        lambda d: d.get("price_shock"),
+    )
+
+    return enhancer
+
+
 def render_report_v3(collection: dict[str, Any], symbol: str, mode: str = "full") -> str:
     """v0.1.3 九模块研究备忘录。mode="brief" 仅输出精简简报。"""
     dims = _index_dims(collection)
     market_structure = collection.get("market_structure") or {}
+
+    # P3-1: 统一增强触发器
+    enhancer = setup_default_enhancers(collection)
+    collection["_enhancements"] = enhancer.apply()
+
     val_cache: dict = {}
     risk_data = _v3_build_risk_report(
         collection, dims, market_structure, val_cache=val_cache,
@@ -4664,6 +4988,7 @@ def render_report_v3(collection: dict[str, Any], symbol: str, mode: str = "full"
             _section_dynamic_drivers(
                 collection, symbol, dims, market_structure, val_cache=val_cache,
             ),
+            _section_holder_changes(dims.get("holder_changes", {})),
             _section_bull_bear(
                 collection, symbol, dims, market_structure, risk_data, val_cache=val_cache,
             ),
@@ -4692,6 +5017,7 @@ def render_report_v3(collection: dict[str, Any], symbol: str, mode: str = "full"
                 collection, symbol, market_structure, val_cache=val_cache,
             ),
             _section_events_timeline(collection),
+            _section_holder_changes(dims.get("holder_changes", {})),
             _section_research_summary(collection, symbol, dims),
             _wrap_details(
                 "展开：静态基本面（12题）",

--- a/skills/invest-A/scripts/lib/schema.py
+++ b/skills/invest-A/scripts/lib/schema.py
@@ -22,6 +22,8 @@ DIMENSIONS = {
     "valuation": "估值分析",
     "research": "机构研报",
     "industry": "行业数据",
+    "holder_changes": "股东增减持",
+    "industry_pricing": "行业定价",
 }
 
 # research 维度在 to_legacy_dict 之外附加的汇总字段（collect_research）

--- a/skills/invest-A/scripts/lib/valuation.py
+++ b/skills/invest-A/scripts/lib/valuation.py
@@ -392,3 +392,287 @@ def _build_summary_text(result: dict[str, Any]) -> str:
         lines.append(f"⚠️ {w}")
 
     return "\n".join(lines)
+
+
+# ═══════════════════════════════════════════════════════════════
+# P2: DCF 估值预处理函数（v0.1.7，供 v0.1.8 DCF 模型使用）
+# ═══════════════════════════════════════════════════════════════
+
+
+def calc_wacc(
+    beta: float,
+    risk_free_rate: float,
+    erp: float,
+    cost_of_debt: float | None = None,
+    tax_rate: float = 0.25,
+    debt_weight: float | None = None,
+) -> dict:
+    """CAPM WACC 计算。
+
+    Args:
+        beta: 5Y 月度收益率 vs 沪深300 回归
+        risk_free_rate: 中国 10Y 国债收益率（小数，如 0.0265）
+        erp: 权益风险溢价（小数，如 0.058）
+        cost_of_debt: 税前债务成本。若为 None，仅返回 cost_of_equity
+        tax_rate: 有效税率
+        debt_weight: 债务权重 D/(D+E)。若为 None 且 cost_of_debt 有值，自动计算
+    """
+    cost_of_equity = risk_free_rate + beta * erp
+
+    if cost_of_debt is None:
+        return {
+            "cost_of_equity": round(cost_of_equity, 6),
+            "wacc": round(cost_of_equity, 6),
+            "components": {
+                "risk_free_rate": risk_free_rate,
+                "beta": beta,
+                "erp": erp,
+            },
+        }
+
+    cost_of_debt_after_tax = cost_of_debt * (1 - tax_rate)
+
+    if debt_weight is None:
+        return {
+            "cost_of_equity": round(cost_of_equity, 6),
+            "cost_of_debt_pre_tax": round(cost_of_debt, 6),
+            "cost_of_debt_after_tax": round(cost_of_debt_after_tax, 6),
+            "wacc": round(cost_of_equity, 6),
+            "warning": "cost_of_debt 已提供但 debt_weight 缺失，WACC 退化为 cost_of_equity",
+            "components": {
+                "risk_free_rate": risk_free_rate,
+                "beta": beta,
+                "erp": erp,
+                "tax_rate": tax_rate,
+                "cost_of_debt_pre_tax": round(cost_of_debt, 6),
+            },
+        }
+
+    equity_weight = 1 - debt_weight
+    wacc = cost_of_equity * equity_weight + cost_of_debt_after_tax * debt_weight
+
+    return {
+        "cost_of_equity": round(cost_of_equity, 6),
+        "cost_of_debt_pre_tax": round(cost_of_debt, 6),
+        "cost_of_debt_after_tax": round(cost_of_debt_after_tax, 6),
+        "wacc": round(wacc, 6),
+        "components": {
+            "risk_free_rate": risk_free_rate,
+            "beta": beta,
+            "erp": erp,
+            "tax_rate": tax_rate,
+            "debt_weight": debt_weight,
+            "equity_weight": equity_weight,
+        },
+    }
+
+
+def calc_fcff(
+    ebit: float,
+    tax_rate: float,
+    depr: float,
+    cap_ex: float,
+    delta_nwc: float = 0,
+) -> dict:
+    """FCFF 计算（单期）。
+
+    FCFF = EBIT × (1 - t) + Depr - CapEx - ΔNWC
+    所有金额单位为元。
+    """
+    nopat = ebit * (1 - tax_rate)
+    fcff = nopat + depr - cap_ex - delta_nwc
+
+    return {
+        "ebit": ebit,
+        "tax_rate": tax_rate,
+        "nopat": round(nopat, 2),
+        "depr": depr,
+        "cap_ex": cap_ex,
+        "delta_nwc": delta_nwc,
+        "fcff": round(fcff, 2),
+        "fcff_margin": round(fcff / ebit, 4) if ebit else None,
+    }
+
+
+def calc_net_debt(debt_total: float, money_cap: float) -> dict:
+    """净债务 = 带息债务 - 货币资金。
+
+    若为负值 → 净现金（企业价值计算时做加法）。
+    """
+    net = debt_total - money_cap
+    return {
+        "debt_total": debt_total,
+        "cash": money_cap,
+        "net_debt": net,
+        "is_net_cash": net < 0,
+    }
+
+
+def calc_ev_to_equity(
+    enterprise_value: float,
+    net_debt: float,
+    shares_outstanding: int,
+) -> dict:
+    """企业价值 → 每股权益价值。
+
+    Args:
+        enterprise_value: ΣPV(FCF) + PV(Terminal)
+        net_debt: 带息债务 - 货币资金（可为负=净现金）
+        shares_outstanding: 总股本（股）
+    """
+    equity_value = enterprise_value - net_debt
+    per_share = equity_value / shares_outstanding if shares_outstanding else None
+
+    return {
+        "enterprise_value": enterprise_value,
+        "net_debt": net_debt,
+        "equity_value": equity_value,
+        "shares_outstanding": shares_outstanding,
+        "per_share": round(per_share, 2) if per_share else None,
+    }
+
+
+def calc_beta(
+    stock_returns: list[float],
+    market_returns: list[float],
+) -> dict:
+    """从收益率序列计算 Beta。
+
+    Args:
+        stock_returns: 个股月度/周度收益率
+        market_returns: 基准（沪深300）同期收益率
+
+    Returns:
+        {"beta": float, "r_squared": float, "observations": int}
+    """
+    import statistics
+
+    n = min(len(stock_returns), len(market_returns))
+    if n < 12:
+        return {"beta": None, "error": f"数据点不足: {n} < 12"}
+
+    mean_s = statistics.mean(stock_returns[:n])
+    mean_m = statistics.mean(market_returns[:n])
+
+    cov = sum(
+        (s - mean_s) * (m - mean_m)
+        for s, m in zip(stock_returns[:n], market_returns[:n])
+    ) / (n - 1)
+    var_m = sum((m - mean_m) ** 2 for m in market_returns[:n]) / (n - 1)
+
+    if abs(var_m) < 1e-12:
+        return {"beta": None, "error": "市场方差为零"}
+
+    beta = cov / var_m
+
+    # R²
+    ss_res = sum(
+        (s - (mean_s + beta * (m - mean_m))) ** 2
+        for s, m in zip(stock_returns[:n], market_returns[:n])
+    )
+    ss_tot = sum((s - mean_s) ** 2 for s in stock_returns[:n])
+    r_squared = 1 - ss_res / ss_tot if ss_tot != 0 else 0
+
+    return {
+        "beta": round(beta, 4),
+        "r_squared": round(r_squared, 4),
+        "observations": n,
+    }
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        f = float(value)
+        if f != f or f in (float("inf"), float("-inf")):
+            return None
+        return f
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_financial_rows(financials: dict) -> list[dict]:
+    """从 financials legacy dict 提取最佳财报行列表（优先 Tushare 源）。"""
+    data = financials.get("data")
+    if isinstance(data, list) and data:
+        return [r for r in data if isinstance(r, dict)]
+
+    all_sources = financials.get("_meta", {}).get("all_sources", [])
+    tushare_rows: list[dict] = []
+    fallback_rows: list[dict] = []
+    for src in all_sources:
+        if not isinstance(src, dict):
+            continue
+        rows = src.get("data")
+        if not isinstance(rows, list) or not rows:
+            continue
+        dict_rows = [r for r in rows if isinstance(r, dict)]
+        if not dict_rows:
+            continue
+        if "tushare" in str(src.get("source", "")):
+            tushare_rows = dict_rows
+        elif not fallback_rows:
+            fallback_rows = dict_rows
+    return tushare_rows or fallback_rows
+
+
+def _latest_financial_row(rows: list[dict]) -> dict | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda r: str(r.get("end_date", "")))
+
+
+def _infer_tax_rate(row: dict) -> float:
+    tax = _as_float(row.get("income_tax") or row.get("tax"))
+    profit = _as_float(row.get("total_profit") or row.get("ebit"))
+    if tax is not None and profit is not None and profit > 0:
+        return max(0.0, min(0.35, tax / profit))
+    return 0.25
+
+
+def build_dcf_preprocess(financials: dict) -> dict | None:
+    """从 financials 维度最新一期数据生成 DCF 预处理块（供 v0.1.8 消费）。"""
+    row = _latest_financial_row(extract_financial_rows(financials))
+    if not row:
+        return None
+
+    out: dict[str, Any] = {
+        "end_date": row.get("end_date"),
+        "status": "partial",
+    }
+    computed: list[str] = []
+
+    ebit = _as_float(row.get("ebit"))
+    if ebit is not None:
+        depr = _as_float(row.get("depr_amort")) or 0.0
+        cap_ex_raw = _as_float(row.get("cap_ex"))
+        cap_ex = abs(cap_ex_raw) if cap_ex_raw is not None else 0.0
+        tax_rate = _infer_tax_rate(row)
+        out["fcff"] = calc_fcff(
+            ebit=ebit,
+            tax_rate=tax_rate,
+            depr=depr,
+            cap_ex=cap_ex,
+        )
+        computed.append("fcff")
+
+    debt_total = _as_float(row.get("total_liab"))
+    money_cap = _as_float(row.get("money_cap"))
+    if debt_total is not None and money_cap is not None:
+        out["net_debt"] = calc_net_debt(debt_total, money_cap)
+        computed.append("net_debt")
+
+    if not computed:
+        return None
+
+    out["computed"] = computed
+    out["status"] = "available" if len(computed) >= 2 else "partial"
+    return out
+
+
+def attach_dcf_preprocess(financials_legacy: dict) -> None:
+    """将 dcf_preprocess 块写入 financials legacy dict（原地）。"""
+    block = build_dcf_preprocess(financials_legacy)
+    if block:
+        financials_legacy["dcf_preprocess"] = block

--- a/skills/invest-A/scripts/references/compliance_rules.yaml
+++ b/skills/invest-A/scripts/references/compliance_rules.yaml
@@ -212,14 +212,14 @@ rules:
     pattern: "^\\d{6}-[^-]+-\\d{4}-?\\d{2}-?\\d{2}\\.md$"
     severity: "info"
     scope: "filename"
-    message: "推荐文件名格式：{symbol}-{name}-{date}.md（如 600176-中国巨石-2026-06-24.md）"
+    message: "推荐路径格式：{symbol}-{name}/{date}.md（如 600176-中国巨石/2026-06-24.md）"
     law_ref: "报告路径 — 个股报告命名规范"
 
   - id: "filename-format-date-symbol"
     pattern: "^\\d{4}-\\d{2}-\\d{2}(-\\d{2}-\\d{2}-\\d{2})?-\\d{6}(-[^-]+)*\\.md$"
     severity: "info"
     scope: "filename"
-    message: "文件名使用日期前缀格式（旧格式，推荐使用 {symbol}-{name}-{date}.md）"
+    message: "文件名使用日期前缀格式（旧格式，推荐使用 {symbol}-{name}/{date}.md）"
     law_ref: "报告路径 — 个股报告命名规范"
 
   # ==========================================================================

--- a/skills/invest-A/tests/test_research.py
+++ b/skills/invest-A/tests/test_research.py
@@ -230,9 +230,22 @@ class TestDefaultDims:
 
         assert "research" not in _DEFAULT_DIMS
 
+    def test_default_dims_include_holder_changes(self):
+        from lib.collector import _DEFAULT_DIMS
+
+        assert "holder_changes" in _DEFAULT_DIMS
+
     def test_invest_parser_default_dims(self):
         from invest import build_parser
 
         parser = build_parser()
         collect_args = parser.parse_args(["collect", "600176"])
         assert "research" not in collect_args.dims
+        assert "holder_changes" in collect_args.dims
+
+    def test_synthesize_parser_default_dims(self):
+        from invest import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["synthesize", "600176"])
+        assert "holder_changes" in args.dims

--- a/skills/invest-A/tests/test_v017.py
+++ b/skills/invest-A/tests/test_v017.py
@@ -1,0 +1,661 @@
+"""v0.1.7 审查修复单元测试。"""
+from __future__ import annotations
+
+import pytest
+
+
+class TestParseHolderChangeVol:
+    def test_ths_text_wan(self):
+        from lib.collector import _parse_holder_change_vol
+
+        assert _parse_holder_change_vol("增持58.11万") == pytest.approx(581100)
+
+    def test_float_passthrough(self):
+        from lib.collector import _parse_holder_change_vol
+
+        assert _parse_holder_change_vol(5901992.0) == pytest.approx(5901992.0)
+
+    def test_nan_returns_none(self):
+        from lib.collector import _parse_holder_change_vol
+
+        assert _parse_holder_change_vol(float("nan")) is None
+
+
+class TestHolderDirectionAndDictHelpers:
+    def test_infer_direction_from_change_type(self):
+        from lib.collector import _infer_holder_direction
+
+        row = {"变动类型": "减持", "变动数量": 1000000.0}
+        assert _infer_holder_direction(row, 1000000.0, 1000000.0) == "减持"
+
+    def test_infer_direction_from_numeric_sign(self):
+        from lib.collector import _infer_holder_direction
+
+        assert _infer_holder_direction({}, -500000.0, -500000.0) == "减持"
+        assert _infer_holder_direction({}, 500000.0, 500000.0) == "增持"
+
+    def test_first_dict_value_preserves_zero(self):
+        from lib.collector import _first_dict_value
+
+        row = {"变动数量": 0, "变动股数": 500}
+        assert _first_dict_value(row, "变动数量", "变动股数") == 0
+
+    def test_source_has_data_rejects_empty_list(self):
+        from lib.collector import _source_has_data
+
+        assert _source_has_data([]) is False
+        assert _source_has_data([{"x": 1}]) is True
+        assert _source_has_data(None) is False
+
+
+class TestMergeHolderRecords:
+    def _sr(self, source: str, records: list[dict]):
+        from lib.schema import SourceResult
+
+        return SourceResult(source, records, "holder_changes")
+
+    def test_same_source_same_day_keeps_both(self):
+        from lib.collector import _merge_holder_records
+
+        ths = self._sr("akshare.stock_shareholder_change_ths", [
+            {
+                "ann_date": "20150917",
+                "holder_name": "定向资产管理计划(振石)",
+                "direction": "增持",
+                "change_vol": 581100.0,
+                "source": "akshare ths",
+            },
+            {
+                "ann_date": "20150917",
+                "holder_name": "定向资产管理计划(振石)",
+                "direction": "增持",
+                "change_vol": 394100.0,
+                "source": "akshare ths",
+            },
+        ])
+        merged = _merge_holder_records([ths])
+        assert len(merged) == 2
+        assert all(r.get("cross_check") == 1 for r in merged)
+
+    def test_cross_source_merges_with_distinct_count(self):
+        from lib.collector import _merge_holder_records
+
+        ts = self._sr("tushare.stk_holdertrade", [{
+            "ann_date": "20260516",
+            "holder_name": "中国建材股份有限公司",
+            "direction": "增持",
+            "change_vol": 5901992.0,
+            "source": "Tushare stk_holdertrade",
+        }])
+        ths = self._sr("akshare.stock_shareholder_change_ths", [{
+            "ann_date": "20260516",
+            "holder_name": "中国建材股份有限公司",
+            "direction": "增持",
+            "change_vol": 5902000.0,
+            "source": "akshare ths",
+        }])
+        merged = _merge_holder_records([ts, ths])
+        assert len(merged) == 1
+        assert merged[0]["cross_check"] == 2
+        assert merged[0]["source"] == "Tushare stk_holdertrade"
+
+    def test_source_rank_prefers_tushare(self):
+        from lib.collector import _merge_holder_records
+
+        ths = self._sr("akshare.stock_shareholder_change_ths", [{
+            "ann_date": "20260516",
+            "holder_name": "中国建材股份有限公司",
+            "direction": "增持",
+            "change_vol": 5902000.0,
+            "source": "akshare ths",
+        }])
+        ts = self._sr("tushare.stk_holdertrade", [{
+            "ann_date": "20260516",
+            "holder_name": "中国建材股份有限公司",
+            "direction": "增持",
+            "change_vol": 5901992.0,
+            "source": "Tushare stk_holdertrade",
+        }])
+        merged = _merge_holder_records([ths, ts])
+        assert merged[0]["source"] == "Tushare stk_holdertrade"
+
+    def test_different_holders_same_prefix_not_merged(self):
+        from lib.collector import _merge_holder_records
+
+        ths = self._sr("akshare.stock_shareholder_change_ths", [{
+            "ann_date": "20260516",
+            "holder_name": "中国建材股份有限公司",
+            "direction": "增持",
+            "change_vol": 1000000.0,
+            "source": "akshare ths",
+        }])
+        ts = self._sr("tushare.stk_holdertrade", [{
+            "ann_date": "20260516",
+            "holder_name": "中国建材集团控股有限公司",
+            "direction": "增持",
+            "change_vol": 1000000.0,
+            "source": "Tushare stk_holdertrade",
+        }])
+        merged = _merge_holder_records([ths, ts])
+        assert len(merged) == 2
+
+
+class TestCalcWacc:
+    def test_no_debt(self):
+        from lib.valuation import calc_wacc
+
+        r = calc_wacc(beta=1.15, risk_free_rate=0.0265, erp=0.058)
+        assert r["wacc"] == pytest.approx(0.0932, abs=1e-4)
+        assert "warning" not in r
+
+    def test_debt_without_weight_warns(self):
+        from lib.valuation import calc_wacc
+
+        r = calc_wacc(
+            beta=1.15, risk_free_rate=0.0265, erp=0.058, cost_of_debt=0.04,
+        )
+        assert r["wacc"] == pytest.approx(0.0932, abs=1e-4)
+        assert "warning" in r
+        assert "debt_weight" not in r["components"]
+
+    def test_debt_with_weight(self):
+        from lib.valuation import calc_wacc
+
+        r = calc_wacc(
+            beta=1.15, risk_free_rate=0.0265, erp=0.058,
+            cost_of_debt=0.04, debt_weight=0.3,
+        )
+        assert r["wacc"] == pytest.approx(0.07424, abs=1e-4)
+        assert r["components"]["equity_weight"] == pytest.approx(0.7)
+
+
+class TestCalcFcff:
+    def test_standard_fcff(self):
+        from lib.valuation import calc_fcff
+
+        r = calc_fcff(ebit=100.0, tax_rate=0.25, depr=20.0, cap_ex=30.0, delta_nwc=5.0)
+        # nopat=75, fcff=75+20-30-5=60
+        assert r["nopat"] == pytest.approx(75.0)
+        assert r["fcff"] == pytest.approx(60.0)
+        assert r["fcff_margin"] == pytest.approx(0.6)
+
+    def test_zero_ebit_no_margin(self):
+        from lib.valuation import calc_fcff
+
+        r = calc_fcff(ebit=0, tax_rate=0.25, depr=10.0, cap_ex=5.0)
+        assert r["fcff_margin"] is None
+
+
+class TestCalcNetDebt:
+    def test_net_debt_positive(self):
+        from lib.valuation import calc_net_debt
+
+        r = calc_net_debt(debt_total=500.0, money_cap=100.0)
+        assert r["net_debt"] == pytest.approx(400.0)
+        assert r["is_net_cash"] is False
+
+    def test_net_cash(self):
+        from lib.valuation import calc_net_debt
+
+        r = calc_net_debt(debt_total=100.0, money_cap=500.0)
+        assert r["net_debt"] == pytest.approx(-400.0)
+        assert r["is_net_cash"] is True
+
+
+class TestCalcEvToEquity:
+    def test_per_share(self):
+        from lib.valuation import calc_ev_to_equity
+
+        r = calc_ev_to_equity(enterprise_value=1000.0, net_debt=200.0, shares_outstanding=100)
+        assert r["equity_value"] == pytest.approx(800.0)
+        assert r["per_share"] == pytest.approx(8.0)
+
+    def test_zero_shares(self):
+        from lib.valuation import calc_ev_to_equity
+
+        r = calc_ev_to_equity(enterprise_value=1000.0, net_debt=0.0, shares_outstanding=0)
+        assert r["per_share"] is None
+
+
+class TestCalcBeta:
+    def test_returns_beta(self):
+        from lib.valuation import calc_beta
+
+        stock = [0.02, 0.01, -0.01, 0.03, 0.0] * 3
+        market = [0.01, 0.005, -0.005, 0.015, 0.0] * 3
+        r = calc_beta(stock, market)
+        assert r["beta"] is not None
+        assert r["observations"] == 15
+
+    def test_insufficient_data(self):
+        from lib.valuation import calc_beta
+
+        r = calc_beta([0.01] * 5, [0.01] * 5)
+        assert r["beta"] is None
+        assert "error" in r
+
+    def test_zero_market_variance(self):
+        from lib.valuation import calc_beta
+
+        r = calc_beta([0.01] * 15, [0.0] * 15)
+        assert r["beta"] is None
+        assert "error" in r
+
+    def test_near_zero_market_variance(self):
+        from lib.valuation import calc_beta
+
+        market = [1e-10] * 15
+        r = calc_beta([0.01] * 15, market)
+        assert r["beta"] is None
+        assert "市场方差为零" in r.get("error", "")
+
+
+class TestIndustryPricingIndustry:
+    def test_dim_wrapper_passes_resolved_industry(self, monkeypatch):
+        captured: dict[str, str] = {}
+
+        def fake_pricing(sym: str, industry: str = "") -> dict:
+            captured["industry"] = industry
+            return {"dimension": "industry_pricing", "data": {"industry": industry}}
+
+        monkeypatch.setattr("lib.collector.collect_industry_pricing", fake_pricing)
+        monkeypatch.setattr(
+            "lib.collector._resolve_industry_for_pricing",
+            lambda sym, dr=None: "玻纤",
+        )
+        from lib.collector import collect_industry_pricing_dim
+
+        collect_industry_pricing_dim("600176")
+        assert captured["industry"] == "玻纤"
+
+    def test_resolve_industry_from_parallel_basic_info(self):
+        from lib.collector import _resolve_industry_for_pricing
+
+        dim_results = {
+            "basic_info": {"data": {"industry": "玻纤"}},
+        }
+        assert _resolve_industry_for_pricing("600176", dim_results) == "玻纤"
+
+
+class TestGetFuturesForIndustry:
+    def test_new_energy_vehicle(self):
+        from lib.chain import get_futures_for_industry
+
+        r = get_futures_for_industry("新能源汽车")
+        assert ("碳酸锂", "LC") in r
+
+    def test_pharma_empty(self):
+        from lib.chain import get_futures_for_industry
+
+        assert get_futures_for_industry("医药生物") == []
+
+
+class TestDetectPriceShock:
+    def test_from_close_sequence(self):
+        from lib.collector import _detect_price_shock
+
+        kline = [
+            {"trade_date": "20260101", "close": 10.0},
+            {"trade_date": "20260102", "close": 11.0},  # +10%
+        ]
+        r = _detect_price_shock("600176", kline)
+        assert r["has_shock"] is True
+        assert r["shock_dates"][0]["type"] == "limit_up"
+
+    def test_empty_no_crash(self):
+        from lib.collector import _detect_price_shock
+
+        r = _detect_price_shock("600176", [])
+        assert r["has_shock"] is False
+
+
+class TestReportEnhancer:
+    def test_has_price_signal(self):
+        from lib.render import _has_price_signal
+
+        data = {
+            "industry_pricing": {
+                "_meta": {
+                    "all_sources": [
+                        {"data": {"signal": "确认"}},
+                    ],
+                },
+            },
+        }
+        assert _has_price_signal(data) is True
+
+    def test_has_price_signal_non_dict_safe(self):
+        from lib.render import _has_price_signal
+
+        assert _has_price_signal({"industry_pricing": "bad"}) is False
+        assert _has_price_signal({}) is False
+
+    def test_valuation_extreme(self, monkeypatch):
+        from lib.render import _is_valuation_extreme
+
+        monkeypatch.setattr(
+            "lib.render._v3_valuation_percentiles",
+            lambda dims, cache: (85.0, 50.0, "偏高"),
+        )
+        collection = {"dimensions": [{"dimension": "valuation", "data": []}]}
+        assert _is_valuation_extreme(collection, percentile=80) is True
+        monkeypatch.setattr(
+            "lib.render._v3_valuation_percentiles",
+            lambda dims, cache: (50.0, 50.0, "适中"),
+        )
+        assert _is_valuation_extreme(collection, percentile=80) is False
+
+
+class TestNewsDateFilter:
+    def test_within_30_days(self):
+        from datetime import datetime, timedelta
+        from lib.collector import _news_date_within
+
+        recent = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S")
+        cutoff = datetime.now() - timedelta(days=30)
+        assert _news_date_within(recent, cutoff) is True
+
+    def test_outside_30_days(self):
+        from datetime import datetime, timedelta
+        from lib.collector import _news_date_within
+
+        cutoff = datetime.now() - timedelta(days=30)
+        assert _news_date_within("2020-01-01 10:00:00", cutoff) is False
+
+
+class TestIndustryPricingRender:
+    def test_futures_in_snapshot_block(self):
+        from lib.render import _render_pricing_futures_section
+
+        block = _render_pricing_futures_section({
+            "data": {
+                "has_futures": True,
+                "industry": "玻璃",
+                "玻璃": {"code": "FG", "spot_price": 1000, "dom_price": 980,
+                         "dom_basis_rate": -0.02, "trend_30d": "↗ +1.0%"},
+            },
+            "_meta": {"all_sources": []},
+        })
+        assert "### 原材料成本速览" in block
+        assert "FG" in block
+
+    def test_futures_pd_na_renders_dash(self):
+        import pandas as pd
+        from lib.render import _render_pricing_futures_section
+
+        block = _render_pricing_futures_section({
+            "data": {
+                "has_futures": True,
+                "industry": "玻璃",
+                "玻璃": {"code": "FG", "spot_price": pd.NA, "dom_price": 980,
+                         "dom_basis_rate": -0.02, "trend_30d": "—"},
+            },
+            "_meta": {"all_sources": []},
+        })
+        assert "nan" not in block.lower()
+        assert "—" in block
+
+    def test_news_in_drivers_block(self):
+        from lib.render import _render_pricing_news_section
+
+        block = _render_pricing_news_section({
+            "data": {"industry": "玻璃"},
+            "_meta": {
+                "all_sources": [{
+                    "source": "akshare.stock_news_em",
+                    "data": {
+                        "signal": "确认",
+                        "signal_detail": "近 30 日 2 条涨价相关新闻",
+                        "matches": [{"date": "2026-06-01", "title": "提价落地"}],
+                    },
+                }],
+            },
+        })
+        assert "### 涨价信号" in block
+        assert "涨价趋势确认" in block
+
+
+class TestRenderHolderChanges:
+    def test_nan_avg_price_renders_dash(self):
+        from lib.render import _section_holder_changes
+
+        section = _section_holder_changes({
+            "data": [{
+                "ann_date": "20260304",
+                "holder_name": "测试股东",
+                "direction": "增持",
+                "change_vol": 1000000,
+                "change_ratio": 0.5,
+                "avg_price": float("nan"),
+                "source": "Tushare stk_holdertrade",
+                "cross_check": 1,
+            }],
+        })
+        assert "## 3d. 股东增减持动向" in section
+        assert "nan" not in section.lower()
+        assert "—" in section
+
+    def test_enhancement_hints_in_extras(self):
+        from lib.render import _render_enhancement_hints
+
+        hints = _render_enhancement_hints({
+            "_enhancements": {
+                "valuation_high_alert": {"triggered": True},
+            },
+        })
+        assert any("历史位置" in h for h in hints)
+        assert not any("估值分位" in h for h in hints)
+
+    def test_enhancement_hints_none_pct_chg_no_crash(self):
+        from lib.render import _render_enhancement_hints
+
+        hints = _render_enhancement_hints({
+            "_enhancements": {
+                "price_shock_detect": {
+                    "has_shock": True,
+                    "shock_type": "连续涨停",
+                    "shock_dates": [{"date": "20260101", "pct_chg": None}],
+                },
+            },
+        })
+        assert any("20260101(—)" in h for h in hints)
+
+
+class TestCollectHolderChangesFallback:
+    def test_empty_tushare_triggers_cninfo(self, monkeypatch):
+        from lib.collector import collect_holder_changes
+        from lib.schema import SourceResult
+
+        cninfo_called = {"value": False}
+
+        def fake_parallel(tasks, dim):
+            return [SourceResult("tushare.stk_holdertrade", [], dim)]
+
+        def fake_cninfo(symbol):
+            cninfo_called["value"] = True
+            return [{"ann_date": "20260101", "direction": "增持", "source": "akshare cninfo"}]
+
+        monkeypatch.setattr("lib.collector._run_sources_parallel", fake_parallel)
+        monkeypatch.setattr("lib.collector._q_akshare_management_hold", fake_cninfo)
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: True)
+        monkeypatch.setattr("lib.collector.env.is_tushare_available", lambda cfg: True)
+
+        collect_holder_changes("600176")
+        assert cninfo_called["value"] is True
+
+    def test_tushare_without_ths_triggers_cninfo(self, monkeypatch):
+        from lib.collector import collect_holder_changes
+        from lib.schema import SourceResult
+
+        cninfo_called = {"value": False}
+
+        def fake_parallel(tasks, dim):
+            return [
+                SourceResult("tushare.stk_holdertrade", [{
+                    "ann_date": "20260101",
+                    "holder_name": "测试",
+                    "direction": "增持",
+                    "change_vol": 1000.0,
+                }], dim),
+                SourceResult("akshare.stock_shareholder_change_ths", [], dim),
+            ]
+
+        def fake_cninfo(symbol):
+            cninfo_called["value"] = True
+            return [{"ann_date": "20260101", "direction": "增持", "source": "akshare cninfo"}]
+
+        monkeypatch.setattr("lib.collector._run_sources_parallel", fake_parallel)
+        monkeypatch.setattr("lib.collector._q_akshare_management_hold", fake_cninfo)
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: True)
+        monkeypatch.setattr("lib.collector.env.is_tushare_available", lambda cfg: True)
+
+        collect_holder_changes("600176")
+        assert cninfo_called["value"] is True
+
+    def test_both_tushare_and_ths_skips_cninfo(self, monkeypatch):
+        from lib.collector import collect_holder_changes
+        from lib.schema import SourceResult
+
+        cninfo_called = {"value": False}
+
+        def fake_parallel(tasks, dim):
+            return [
+                SourceResult("tushare.stk_holdertrade", [{
+                    "ann_date": "20260101",
+                    "holder_name": "测试",
+                    "direction": "增持",
+                    "change_vol": 1000.0,
+                }], dim),
+                SourceResult("akshare.stock_shareholder_change_ths", [{
+                    "ann_date": "20260101",
+                    "holder_name": "测试",
+                    "direction": "增持",
+                    "change_vol": 1000.0,
+                }], dim),
+            ]
+
+        def fake_cninfo(symbol):
+            cninfo_called["value"] = True
+            return [{"ann_date": "20260101", "direction": "增持", "source": "akshare cninfo"}]
+
+        monkeypatch.setattr("lib.collector._run_sources_parallel", fake_parallel)
+        monkeypatch.setattr("lib.collector._q_akshare_management_hold", fake_cninfo)
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: True)
+        monkeypatch.setattr("lib.collector.env.is_tushare_available", lambda cfg: True)
+
+        collect_holder_changes("600176")
+        assert cninfo_called["value"] is False
+
+
+class TestAkshareCompanyNewsPrice:
+    def test_uses_direct_session(self, monkeypatch):
+        from lib.collector import _q_akshare_company_news_price
+
+        calls = {"direct": 0, "news": 0}
+
+        class FakeCtx:
+            def __enter__(self):
+                calls["direct"] += 1
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        def fake_news(symbol):
+            calls["news"] += 1
+            return None
+
+        monkeypatch.setattr("lib.collector.akshare_direct_session", lambda: FakeCtx())
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: True)
+        monkeypatch.setattr("akshare.stock_news_em", fake_news)
+
+        _q_akshare_company_news_price("600176")
+        assert calls["direct"] == 1
+        assert calls["news"] == 1
+
+
+class TestCninfoManagementHold:
+    def test_missing_symbol_column_skips(self, monkeypatch):
+        import pandas as pd
+        from lib.collector import _q_akshare_management_hold
+
+        df = pd.DataFrame([{"董监高姓名": "张三", "变动数量": 1000}])
+
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: True)
+        monkeypatch.setattr(
+            "akshare.stock_hold_management_detail_cninfo",
+            lambda symbol: df,
+        )
+
+        assert _q_akshare_management_hold("600176") is None
+
+    def test_timeout_skips_direction(self, monkeypatch):
+        import time
+        from lib.collector import _q_akshare_management_hold
+
+        def slow_cninfo(symbol):
+            time.sleep(2)
+            return None
+
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: True)
+        monkeypatch.setattr("lib.collector.env.CNINFO_HOLDER_TIMEOUT_SEC", 0)
+        monkeypatch.setattr(
+            "akshare.stock_hold_management_detail_cninfo",
+            slow_cninfo,
+        )
+
+        assert _q_akshare_management_hold("600176") is None
+
+
+class TestDcfPreprocess:
+    def test_build_from_latest_period(self):
+        from lib.valuation import attach_dcf_preprocess, build_dcf_preprocess
+
+        financials = {
+            "data": [
+                {"end_date": "20240331", "ebit": 1e9},
+                {
+                    "end_date": "20241231",
+                    "ebit": 2e9,
+                    "depr_amort": 3e8,
+                    "cap_ex": -4e8,
+                    "income_tax": 2e8,
+                    "total_profit": 1e9,
+                    "total_liab": 5e9,
+                    "money_cap": 1e9,
+                },
+            ],
+        }
+        block = build_dcf_preprocess(financials)
+        assert block is not None
+        assert block["end_date"] == "20241231"
+        assert block["fcff"]["fcff"] == pytest.approx(1.5e9, rel=1e-3)
+        assert block["net_debt"]["net_debt"] == pytest.approx(4e9)
+
+        attach_dcf_preprocess(financials)
+        assert financials["dcf_preprocess"]["status"] == "available"
+
+    def test_collect_financials_attaches_preprocess(self, monkeypatch):
+        from lib.collector import collect_financials
+        from lib.schema import SourceResult
+
+        rows = [{
+            "end_date": "20241231",
+            "ebit": 1e9,
+            "depr_amort": 1e8,
+            "cap_ex": 2e8,
+            "total_liab": 3e9,
+            "money_cap": 5e8,
+        }]
+
+        monkeypatch.setattr(
+            "lib.collector._run_sources_parallel",
+            lambda tasks, dim: [SourceResult("tushare.fina_indicator", rows, dim)],
+        )
+        monkeypatch.setattr("lib.collector.env.is_tushare_available", lambda cfg: True)
+        monkeypatch.setattr("lib.collector.env.is_akshare_available", lambda: False)
+
+        legacy = collect_financials("600176")
+        assert "dcf_preprocess" in legacy
+        assert legacy["dcf_preprocess"]["computed"] == ["fcff", "net_debt"]
+

--- a/skills/invest-A/tests/test_v017_e2e.py
+++ b/skills/invest-A/tests/test_v017_e2e.py
@@ -1,0 +1,84 @@
+"""v0.1.7 Step 8 端到端冒烟（live 数据源）。
+
+默认跳过；本地或发布前执行：
+
+    INVEST_RUN_E2E=1 uv run pytest skills/invest-A/tests/test_v017_e2e.py -v
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from lib.collector import _DEFAULT_DIMS, attach_phase2_extras, collect_all
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("INVEST_RUN_E2E") != "1",
+    reason="live e2e: set INVEST_RUN_E2E=1",
+)
+
+# v0.1.7-implementation-plan.md Step 8.2
+E2E_SYMBOLS = ("600176", "000858", "600519", "000001")
+
+
+def _dim_map(collection: dict) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for dim in collection.get("dimensions", []):
+        if isinstance(dim, dict) and dim.get("dimension"):
+            out[str(dim["dimension"])] = dim
+    return out
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("symbol", E2E_SYMBOLS)
+def test_collect_all_default_dims_no_regression(symbol: str):
+    """四标的默认维度采集不报错，且含 v0.1.7 新增 holder_changes。"""
+    result = collect_all(symbol, dims=list(_DEFAULT_DIMS))
+    summary = result.get("summary") or {}
+    assert summary.get("total", 0) >= len(_DEFAULT_DIMS)
+
+    dims = _dim_map(result)
+    assert "holder_changes" in dims
+    assert "financials" in dims
+    assert dims["holder_changes"].get("status") in ("available", "partial", "missing")
+
+    fin = dims.get("financials") or {}
+    if fin.get("status") == "available":
+        assert fin.get("dcf_preprocess") is not None or fin.get("data")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("symbol", E2E_SYMBOLS)
+def test_attach_phase2_extras_industry_pricing(symbol: str):
+    """attach_phase2_extras 挂载 industry_pricing / price_shock。"""
+    result = collect_all(symbol, dims=list(_DEFAULT_DIMS))
+    attach_phase2_extras(result, symbol)
+
+    assert "industry_pricing" in result
+    ip = result["industry_pricing"]
+    assert isinstance(ip, dict)
+    assert ip.get("dimension") == "industry_pricing"
+
+    shock = result.get("price_shock")
+    assert isinstance(shock, dict)
+    assert "has_shock" in shock
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("symbol", E2E_SYMBOLS)
+def test_report_v3_renders_v017_sections(symbol: str):
+    """report 渲染含 v0.1.7 章节骨架（增减持 / 行业定价）。"""
+    from lib.render import render_report_v3
+
+    result = collect_all(symbol, dims=list(_DEFAULT_DIMS))
+    attach_phase2_extras(result, symbol)
+    md = render_report_v3(result, symbol, mode="full")
+
+    assert len(md) > 800
+    assert "风险" in md
+    dims = _dim_map(result)
+    hc = dims.get("holder_changes") or {}
+    if hc.get("status") == "available" and hc.get("data"):
+        assert "## 3d. 股东增减持动向" in md
+    # industry_pricing 可能仅新闻源（无期货映射行业）
+    assert "行业产品定价" in md or "原材料成本速览" in md or "涨价" in md

--- a/skills/invest-A/tests/test_version_sync.py
+++ b/skills/invest-A/tests/test_version_sync.py
@@ -1,0 +1,123 @@
+"""version_sync.py — 版本收敛工具测试。"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import version_sync  # noqa: E402
+
+
+def _write_fixture_tree(root: Path, version: str) -> None:
+    (root / "skills" / "invest-A").mkdir(parents=True)
+    (root / ".claude-plugin").mkdir(parents=True)
+
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "test"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    (root / "skills" / "invest-A" / "SKILL.md").write_text(
+        f'---\nname: invest-A\nversion: "{version}"\n---\n',
+        encoding="utf-8",
+    )
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "invest-A", "version": version}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (root / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({"plugins": [{"name": "invest-A", "version": version}]}, indent=2)
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "gemini-extension.json").write_text(
+        json.dumps({"name": "invest-A-skill", "version": version}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestVersionSyncInRepo:
+    def test_check_passes_in_repo(self):
+        assert version_sync.cmd_check(_REPO_ROOT) == 0
+
+    def test_show_matches_pyproject(self):
+        shown = version_sync.read_canonical_version(_REPO_ROOT)
+        from_pyproject = version_sync.read_pyproject_version(_REPO_ROOT / "pyproject.toml")
+        assert shown == from_pyproject
+
+
+class TestVersionSyncBump:
+    def test_bump_updates_all_targets(self, tmp_path: Path):
+        _write_fixture_tree(tmp_path, "0.1.0")
+        assert version_sync.cmd_bump(tmp_path, "0.1.8") == 0
+        assert version_sync.cmd_check(tmp_path) == 0
+        assert version_sync.read_canonical_version(tmp_path) == "0.1.8"
+
+    def test_check_fails_on_mismatch(self, tmp_path: Path):
+        _write_fixture_tree(tmp_path, "0.1.0")
+        plugin = tmp_path / ".claude-plugin" / "plugin.json"
+        data = json.loads(plugin.read_text(encoding="utf-8"))
+        data["version"] = "9.9.9"
+        plugin.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        assert version_sync.cmd_check(tmp_path) == 1
+
+    def test_bump_rolls_back_on_failure(self, tmp_path: Path, monkeypatch):
+        _write_fixture_tree(tmp_path, "0.1.0")
+        real_write = version_sync.write_target_version
+        calls = {"n": 0}
+
+        def flaky_write(root, target, ver):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise ValueError("simulated write failure")
+            return real_write(root, target, ver)
+
+        monkeypatch.setattr(version_sync, "write_target_version", flaky_write)
+        assert version_sync.cmd_bump(tmp_path, "0.9.9") == 1
+        assert version_sync.read_pyproject_version(tmp_path / "pyproject.toml") == "0.1.0"
+
+
+class TestJsonVersionPreservesFormatting:
+    def test_plugin_json_only_touches_version_line(self, tmp_path: Path):
+        path = tmp_path / "plugin.json"
+        original = (
+            '{\n'
+            '  "name": "invest-A",\n'
+            '  "version": "0.1.0",\n'
+            '  "description": "keep me"\n'
+            "}\n"
+        )
+        path.write_text(original, encoding="utf-8")
+        version_sync.write_json_version(path, ".claude-plugin/plugin.json", "0.1.8")
+        assert path.read_text(encoding="utf-8") == original.replace("0.1.0", "0.1.8")
+
+
+class TestMarketplaceNestedVersion:
+    def test_read_by_plugin_name_not_index(self, tmp_path: Path):
+        path = tmp_path / "marketplace.json"
+        original = (
+            '{\n'
+            '  "plugins": [\n'
+            '    {"name": "other-plugin", "version": "9.9.9"},\n'
+            '    {"name": "invest-A", "version": "0.1.5"}\n'
+            "  ]\n"
+            "}\n"
+        )
+        path.write_text(original, encoding="utf-8")
+        assert version_sync.read_json_version(path, ".claude-plugin/marketplace.json") == "0.1.5"
+        version_sync.write_json_version(path, ".claude-plugin/marketplace.json", "0.1.9")
+        assert path.read_text(encoding="utf-8") == original.replace("0.1.5", "0.1.9")
+
+    def test_bump_updates_marketplace_nested_path(self, tmp_path: Path):
+        _write_fixture_tree(tmp_path, "0.1.1")
+        version_sync.cmd_bump(tmp_path, "0.2.0")
+        marketplace = json.loads(
+            (tmp_path / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+        )
+        assert marketplace["plugins"][0]["version"] == "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,7 @@ wheels = [
 
 [[package]]
 name = "investment-learning-skill"
-version = "0.1.6"
+version = "0.1.7"
 source = { virtual = "." }
 dependencies = [
     { name = "akshare" },


### PR DESCRIPTION
## v0.1.7 交付

**26 files changed | +2764 / -228 | 612 tests passed**

### 核心新增（P0-P3）

| 优先级 | 功能 | 文件 |
|:------:|------|------|
| **P0-1** | Tushare income/cashflow/balancesheet 补齐 EBIT/CapEx/净债务字段 | collector.py |
| **P0-2** | holder_changes 维度 — 三源（Tushare + akshare ths/cninfo）增减持采集去重渲染 | collector.py, render.py |
| **P1-1** | chain.py 期货映射 get_futures_for_industry() | chain.py |
| **P1-2** | industry_pricing 维度 — 期货现货价 + 涨价新闻信号 | collector.py, render.py |
| **P2** | 估值预处理: calc_wacc / calc_fcff / calc_net_debt / calc_ev_to_equity / calc_beta | valuation.py |
| **P3** | PRICE_NEWS_WHITELIST + ReportEnhancer + 价格异常检测原型 | env.py, render.py |

### 版本号收敛

- 新增 scripts/version_sync.py — pyproject.toml 为 canonical，同步 5 个分发 manifest
- CLAUDE.md 摘除版本行（不再作为 version target）
- bump-version.sh / check-version.sh 委托给 version_sync.py

### 三轮 Code Review 修复

1. _merge_holder_records: 修复 source_rank key、同源同日多笔保留、cross_check 仅计 distinct 源
2. 渲染: NaN → '—'、章节编号 3d/3e、期货双日期趋势、brief 模式补 holder_changes
3. cninfo 回退逻辑、synthesize dims 对齐、_has_price_signal 安全、calc_beta epsilon、cmd_bump 回滚、措辞规范

### 测试

- test_v017.py: 548 行 — DCF 函数、增减持解析合并、价格异常检测、期货映射、ReportEnhancer 触发器
- test_v017_e2e.py: 84 行 — 四标的 collect/report 冒烟
- test_version_sync.py: 90 行 — bump/check/show 完整覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)