### PR TITLE
fix(B): v0.2.8 补丁 — WB 运行时 U+2028 字节修复 + 报告协议默认 html

### DIFF
--- a/skills/invest-a-etf/SKILL.md
+++ b/skills/invest-a-etf/SKILL.md
@@ -66,7 +66,7 @@ Claude: 确认 6 位代码
        ↓
 Claude: 合成分析（见下方「分析合成」节）→ 写入 reports/{symbol}-{name}/{timestamp}.md
        ↓
-可选: etf.py html SYMBOL --md <刚写好的 md>  → 生成交互式 HTML 并自动在浏览器打开（详见「HTML 产物」节）
+默认（报告落盘后必做）: etf.py html SYMBOL --md <刚写好的 md>  → 同目录生效交互式 HTML（--no-open 落盘；详见「HTML 产物」节）
 
 **报告文件命名规则**：
 - `{timestamp}` = 报告生成时的实际时间，格式 `YYYY-MM-DD-HH-MM-SS`（北京时间）
@@ -105,7 +105,7 @@ cd "${INVEST_SKILLS_ROOT:-.}" && uv run python skills/invest-a-etf/scripts/etf.p
 
 **交互式 HTML 报告**（`html` 子命令）：引擎数据仪表盘（概览/持仓/估值/跟踪/历史/资金流等 8 节 + Chart.js 交互图表）+ 已过复检的报告 md 分析全文原样嵌入。单文件自包含（图表库内联），file:// 离线可用。
 
-- **推荐用法**：报告 md 写入后，显式传 `--md` 指向刚写的文件（本工作流下你掌握确切路径；不同 harness 下报告目录位置不必假设一致）：
+- **默认用法**：报告 md 写入后执行（默认动作），显式传 `--md` 指向刚写的文件——本工作流下你掌握确切路径；不同 harness 下报告目录位置不必假设一致
 
 ```bash
 cd "${INVEST_SKILLS_ROOT:-.}" && uv run python skills/invest-a-etf/scripts/etf.py html 515050 --md reports/515050-通信ETF/2026-08-28-22-47-25.md

--- a/skills/invest-a-stock/SKILL.md
+++ b/skills/invest-a-stock/SKILL.md
@@ -451,7 +451,7 @@ STEP 4 事件链挖掘（公告 + 新闻 + 订单/临床/扩产里程碑）：�
 
 ### 分析协议（analysis.json，v0.2.8）
 
-报告步骤产出三类产物，同目录并存：`md + analysis.json + html`（html 仅在 `--emit html` 时）。
+报告步骤产出三类产物，同目录并存：`md + analysis.json + html`（**html 为默认产物**，经 `--emit html` 与 md 同代重渲落盘）。
 
 1. **先出 md**：`report SYMBOL` → `reports/{symbol}-{name}/{ts}.md`（分析段以占位符保留，qc 的 F0-3 会拦截未填占位——**正文写完立刻填写**）
 2. **再写分析协议**：`reports/{symbol}-{name}/{ts}.analysis.json`，段结构：
@@ -459,12 +459,11 @@ STEP 4 事件链挖掘（公告 + 新闻 + 订单/临床/扩产里程碑）：�
    - `facts_md`：事实块（带 [来源: ...]）；`analysis_md`：逻辑推演（带 [证据: X] / [证据强度: ...]）
    - `evidence_tag`：A-D 或 L1-L4；`position` ∈ events/valuation/financials/northbound/holders/refs/conclusion
    - 校验：`uv run python skills/invest-a-stock/scripts/invest.py ... --analysis <path>`（校验失败 fail-loud 退出）
-3. **复合重渲**：`report SYMBOL --analysis <path>`（或 `--resume`）→ 分析段替换占位 → md/html 同源消费
+3. **复合重渲（默认出 html）**：`report SYMBOL --analysis <path> --emit html`（或 `--resume`）→ 分析段替换占位 → **html + 同代 md 同源落盘**（`--emit html` 分支同时写 md_v2，保证 md/html 同代；不重渲则以 md 为唯一产物，属例外情形）
 
 ### HTML 产物
 
-- 生成：`uv run python skills/invest-a-stock/scripts/invest.py report SYMBOL --emit html --outdir reports`
-  → `reports/{symbol}-{name}/{ts}.html`（单文件自包含，无 CDN，file:// 离线可用）
+- 默认路径：步骤 3 的 `--emit html`（而非可选步骤），`reports/{symbol}-{name}/{ts}.html`（单文件自包含，无 CDN，file:// 离线可用）
 - 若 `<script>` 未内联图表库（资产缺失）报告仍正常出稿（图表 disabled），语义同「数据缺失降级」
 - `--analysis <path>` 在 HTML 中同样生效（分析段渲染进页面）
 

--- a/skills/invest-a-stock/scripts/lib/render_html.py
+++ b/skills/invest-a-stock/scripts/lib/render_html.py
@@ -549,8 +549,8 @@ def _json_js(obj: Any) -> str:
     """
     return (json.dumps(obj, ensure_ascii=False)
             .replace("</", "<\\/")
-            .replace(" ", "\\u2028")
-            .replace(" ", "\\u2029"))
+            .replace("\u2028", "\\u2028")
+            .replace("\u2029", "\\u2029"))
 
 
 def _chart_block(chart_id: str, title_html: str, opts: dict,


### PR DESCRIPTION
## v0.2.8 发布后补丁

### 1. `_json_js` 真实 U+2028/U+2029 字节 → ASCII 转义（WB 运行时修复）

`skills/invest-a-stock/scripts/lib/render_html.py:552-553` 字符串字面量混入**真实 U+2028/U+2029 字符**（T4-1 引入）：
- Python ≥3.12（本地/CI）：字面量合法，未暴露
- **Python <3.12（WorkBuddy 运行时）**：tokenizer 视为行终止符 → 字符串被裸换行破坏

改为 ASCII 转义 `" "`/`" "`（与 etf_html.py:1078 同款），所有 Python 版本语法一致。全仓复查无其他真实 U+2028/U+2029 字节。

### 2. 报告产物协议默认 html

- invest-a-stock/SKILL.md：html 从「仅在 `--emit html` 时」改为默认产物——步骤 3 复合重渲默认带 `--emit html`（html + 同代 md 同源落盘，WB/主版共享同一协议）
- invest-a-etf/SKILL.md：工作流 html 步骤「可选」→「默认（报告落盘后必做）」

### 验证
- 全量 pytest exit 0（先清掉与并发 uv 锁竞争的孤儿进程后串行复跑）
- render_html 5 个测试文件全绿（render_html / render_v2 / render_extras / render_concise_fixes / render_code_review_fixes）